### PR TITLE
Create snapshot of arxlive ElasticSearch Domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+!**src/node_modules
+.prettierignore

--- a/arxlive_spotlight_annotation/package-lock.json
+++ b/arxlive_spotlight_annotation/package-lock.json
@@ -1,0 +1,1439 @@
+{
+  "name": "dap_dv_backends",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dap_dv_backends",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^2.0.1",
+        "@aws-sdk/credential-provider-node": "^3.49.0",
+        "@aws-sdk/node-http-handler": "^3.49.0",
+        "@aws-sdk/protocol-http": "^3.49.0",
+        "@aws-sdk/signature-v4": "^3.49.0",
+        "commander": "^9.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.1.tgz",
+      "integrity": "sha512-P4Af7E2iJqZN2HYMdWINEg++OC2CtP1ygTx6WQCzZISQA+i3Q+K3E8S8t/PSYqUnvtfh5XVjbFT9uA+4IT8C2w==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.1",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.1",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
+      "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.49.0.tgz",
+      "integrity": "sha512-1qLlgOgg3yrtm+AJEP7yoIk90o6ns3Dia8S9DRjj29jY40446etH3v/tIbHPE+em69HLXl1K6e5KD6t7EDxnlg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.49.0.tgz",
+      "integrity": "sha512-rY8uZo4DeNwwKf+Sx0TX/5ysXJKf+0SQSCTWD9S4a0AjtiaLc6hKCX+sJY43VDHvNYieKtXLDYHBdhhqZKwG+g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.49.0",
+        "@aws-sdk/fetch-http-handler": "3.49.0",
+        "@aws-sdk/hash-node": "3.49.0",
+        "@aws-sdk/invalid-dependency": "3.49.0",
+        "@aws-sdk/middleware-content-length": "3.49.0",
+        "@aws-sdk/middleware-host-header": "3.49.0",
+        "@aws-sdk/middleware-logger": "3.49.0",
+        "@aws-sdk/middleware-retry": "3.49.0",
+        "@aws-sdk/middleware-serde": "3.49.0",
+        "@aws-sdk/middleware-stack": "3.49.0",
+        "@aws-sdk/middleware-user-agent": "3.49.0",
+        "@aws-sdk/node-config-provider": "3.49.0",
+        "@aws-sdk/node-http-handler": "3.49.0",
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/smithy-client": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/url-parser": "3.49.0",
+        "@aws-sdk/util-base64-browser": "3.49.0",
+        "@aws-sdk/util-base64-node": "3.49.0",
+        "@aws-sdk/util-body-length-browser": "3.49.0",
+        "@aws-sdk/util-body-length-node": "3.49.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.49.0",
+        "@aws-sdk/util-defaults-mode-node": "3.49.0",
+        "@aws-sdk/util-user-agent-browser": "3.49.0",
+        "@aws-sdk/util-user-agent-node": "3.49.0",
+        "@aws-sdk/util-utf8-browser": "3.49.0",
+        "@aws-sdk/util-utf8-node": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.49.0.tgz",
+      "integrity": "sha512-4kYV+89E9MG+/wfPY3dmwqzquQxNd951jdfjQbSg1ii68X/owqmWda4bLulV0Z4iGUz9TXkbaJCWyRyjsFNe4w==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-config-provider": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.49.0.tgz",
+      "integrity": "sha512-mx82N0un6URmmiM11X3ObK3ka5R99lEFdhwPc0jqsCPnXRVioUtK5DXkJ8FmgixbDcs5Pdij9A8MINSeBrG0bQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.49.0.tgz",
+      "integrity": "sha512-d/H5VgmRiIupQdPg9QcX16kdvuiS/YytRYCQOncVstNXHvYZM9EgeIXJLXyPNaD2W8SS7CBf4KKWYJn3V+9AZw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/url-parser": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.49.0.tgz",
+      "integrity": "sha512-QlWfxDwZVyX36pghgkKGBR+fBmX/mjmvc0kzxUmqGhUYAkDQ0YKR11ybpGBrxBKT4lIOE+9z6Tu4nLjp3OlJIg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.49.0",
+        "@aws-sdk/credential-provider-imds": "3.49.0",
+        "@aws-sdk/credential-provider-sso": "3.49.0",
+        "@aws-sdk/credential-provider-web-identity": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-credentials": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.49.0.tgz",
+      "integrity": "sha512-DonoqOZHcqfNuwMG1fGJpHJTqf1QinihRKzlOoUWzmseqBCiuagGouSN7nOQgee5BrzF0X9/nao9lnPc4on2TA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.49.0",
+        "@aws-sdk/credential-provider-imds": "3.49.0",
+        "@aws-sdk/credential-provider-ini": "3.49.0",
+        "@aws-sdk/credential-provider-process": "3.49.0",
+        "@aws-sdk/credential-provider-sso": "3.49.0",
+        "@aws-sdk/credential-provider-web-identity": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-credentials": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.49.0.tgz",
+      "integrity": "sha512-Zn7CJHoXln8O+yBKdTBvcwCz6GDh48s7HtIsqjoOrqoL0oZWhgy8gn8S9KQ+HIqpiO8N0lMMteXuPl5fbC2zGg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-credentials": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.49.0.tgz",
+      "integrity": "sha512-sFTqbQOyGR88K10Y1OgauEPKDmEibxtAkLSFjkJ6Yw/Jyp+lftchoa+TxRrNvDY1zjZX+XauVI6UmD5Pi4E1NQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-credentials": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.49.0.tgz",
+      "integrity": "sha512-mlIHUTn04unB0HEwEO12YIY5848uE9B+gYI+YwlNZ70KXGs3lj2horOgPgbxeIfulCVw0aRTKChUg2ActTosYg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.49.0.tgz",
+      "integrity": "sha512-ougJRsvoIGP0qTgHSGVF1B5Ui95Y/SP5CpY/y6B8vMGrwJ+MmvcCUE3Qd2UJGjO1PfUneno8PHK4u5x7hc2ceA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/querystring-builder": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-base64-browser": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.49.0.tgz",
+      "integrity": "sha512-nRNCmSkcJOzWzKU6NihlKW/6H1HxaaBjUe9ETnwWIgwPC7NZ6IWtri48Cf7Itvveu3dln3ZM2WSXN20TlQpuBw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-buffer-from": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.49.0.tgz",
+      "integrity": "sha512-MXf/9l/Oiy+KGKDvInv0RT4rtS+iNftYRTlTmUn3RR74Kz8Fvw+O0RcUjzSrNn5SpjCf/UsGrF+KBTm2gFYQCA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.49.0.tgz",
+      "integrity": "sha512-tLba+xvlm1+aAnv+bGieVZo8DCENbqfS9kLf/hp+9hrUSiNAsxs9Pqi34JBpMKGn6h9qORp6f8ClRS+gK8yvWg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.49.0.tgz",
+      "integrity": "sha512-7IaghPT7X92gNoyn9LzZj4V5YpGPDCYQTWhpzZoIlw88vOR4I0zKg7jwYeElRoNfRCI4OYhF26ajKnNHzNMlbA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.49.0.tgz",
+      "integrity": "sha512-5l1ILqHs2mGqNvJb5mRe7hHbTQOO292jghE/LItpNx2tiu7BBGzP1bslHcyEVYoRBX9Oqyfou7s9Ww2yBWtImQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.49.0.tgz",
+      "integrity": "sha512-OicQ0w5sCJXgpeZ+t3XeJA2R/09YfuSe53Ma6aWZm/2/r8vG/SW0yAnwFvwJeCm3DKtBxU1qO2eWhFqvJuWRVA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.49.0.tgz",
+      "integrity": "sha512-RSS4R4PNULHA1b1eYR50YPPfOV2jRuXgLNLVVYMEzzC23MabKEXJYPge+pI1Q9rRrbahVj7aQcOTSpT0MsiEeA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/service-error-classification": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.49.0.tgz",
+      "integrity": "sha512-bMAlwR19uFUZ4om+U+/vnPvkcyYw83HdtERF9wrjAqNUnqYsifA0xn4R7Sakg6CW8V0h82dsST6zVfmHd+E2VA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.49.0.tgz",
+      "integrity": "sha512-OZxs2P7EH58gkvkTI7ESlUPGam0TkE0ZxOX35KjCOcYMuWvTMshKBzHRLX64nz3DYdaHSIGHgB1v8LKELZjltw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.49.0.tgz",
+      "integrity": "sha512-uAcKgafZ12L8UnyeQGgSFtwOKUfiBWDLt4P2fEHvZRz/HAIcK4pu1PXPArjwteinhUiCDNFfPw8hAPvstMoG6w==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.49.0.tgz",
+      "integrity": "sha512-OCn5c6M/RJDEO80Q+Iy4ADSYgqd/uyEsvp+7lU4di4bMND9kYT4JO2ky2SWjIuARGq/mhMOhaN2DO9MbcqV20g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.49.0.tgz",
+      "integrity": "sha512-t7D9hoSigBihC9RRgYrkzgSER0fYzZe7192pJAaP6jk13ZOpccQRfXZoKge/cm42aHJsTy8DdQdGtLg7wLTp0g==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.49.0",
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/querystring-builder": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.49.0.tgz",
+      "integrity": "sha512-6D48YpriOUpniezVuRI8J+MG+vgwb5C1SzBdgN4+S6DqbsEZy+kdEubXdoMICEd+Z8h7lH3p5zMr6po0icGCfA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.49.0.tgz",
+      "integrity": "sha512-lb9CO7/vm26v4UwveWb4jSapqWWP/p0b9SuHpRExq+yMuvHqwxcoGrxmvS7FsanWbepRF1895dxU/Ar6/4pviA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.49.0.tgz",
+      "integrity": "sha512-+NlgIYihVyUetZcrF1ADY0eg8WW1/ETD5bzTwguTiKduXVHmavSakXK1jJF5vg05mefljToZXjQnOaEs9+K9LA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-uri-escape": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.49.0.tgz",
+      "integrity": "sha512-4bSCHI5A8wi+JjsD1gAhMuGRGjDmlw6MoMWUiv4R2J8Ow/9mV8biKRo2ZytUPiSSu4G5JQ7mEkqFsm/VgkstDQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.49.0.tgz",
+      "integrity": "sha512-iVmf7RcrIsM/We5ip8fe14RzEpSLF5eN8oqhCMftEdmMVnOYMd/9x0f1w69fbyBJNIIpyREqM8eAKz5OWQn5/g==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.49.0.tgz",
+      "integrity": "sha512-TcgKU6U/3JZpenRFhGSy5R5QsBWkYoeawTK1rTK6deu3UbxVwtOkietbfwP3kIwKZ4hz6OkNeHcOJtXX/InZKw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.49.0.tgz",
+      "integrity": "sha512-mQSGclWmv/9/MsgthBuKMHN6nkkhGTLXspkhqJ9xSUhjhoaHQVwMoJc39PowJGbYFn1AtCvHAqJtFXTGsMRwPA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-hex-encoding": "3.49.0",
+        "@aws-sdk/util-uri-escape": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.49.0.tgz",
+      "integrity": "sha512-ANh9SlEvuru1DcalVoQ7K6wSCYuw4jyeTsIDsJSa13ckrmXAg+ql9vq61ELAXTSNVmuAISuuPjbVaWvOYCtdCQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.49.0.tgz",
+      "integrity": "sha512-8bCqEpquTlPN6xkjaJ+s+RoEFIu5r4G8oXOsQ5HYBvBdpx62HnCqzHLFNHycL2b8sE+VysQgNvmdQYR98vdMGQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.49.0.tgz",
+      "integrity": "sha512-l5td6eu+sIjzNsZYVGr7Mz6vssf2j/8/QrrTYF76J2R6OoceCsKdyJgJPP/tXBdcp4HUZDdVcMqtWRbxGC4izQ==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.49.0.tgz",
+      "integrity": "sha512-HFXJbsJC6AfrnO9M8KuFDo4ihvLbCbCFCfpWy0Gs4t8kTcvGqH8fIpfVsQKAtFHMmb8fen2LduOk+NNSA7srYw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.49.0.tgz",
+      "integrity": "sha512-xFAzOLZJOEZipG3KVLjB5z1g5PJSi6cmZOGWg2NC2/H5N0/Z+e5ObnIH8mpfO1d6kWchUuo3qJ6fTOvg/ynw7A==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.49.0.tgz",
+      "integrity": "sha512-4a9Bw33JGKefaZDORlosQRMKxJGEYEiDD5kgNvwIv+KRl5yj2unePia6aFWMqXTWqidOb9WVlqc0Lh73ei5pTg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.49.0.tgz",
+      "integrity": "sha512-ME5Sc8jo9BzToUjWskQKZM/NqN9PpwRDTOSH6EISDBUiH5bhWfY8MLkZqIN2UZz/XOiV3yOeWAU+fMYNnGdAQQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.49.0.tgz",
+      "integrity": "sha512-8JbIPYn91f+16QpDk000PdIBlBZu8/SoL1nF2fpAJ+M98jXpKUws3oiCztJ2FPIKRe/3ikKuZM4HxWrDyJa40Q==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.49.0.tgz",
+      "integrity": "sha512-oVGT9q9UIGdv9Cra4B51QNciWKYQXTlfh8oD2FgLp91NbGTIkQLvK7Pah4TbBoa5+0u/obBI07UwCVn7wphWBQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-credentials": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.49.0.tgz",
+      "integrity": "sha512-RzbKeuylb56m0zPuLGl5/TkN07+c4PKhZu3hikpsvN8n8n7aFHWPUus63QEGgVaUMCZD0QV6HqJfsCVVFF7UIg==",
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.49.0.tgz",
+      "integrity": "sha512-MNOvFET5TNBHgvsmfcLuxVDDUV0OIjE1lxrdbXWol7bMgLc2uL3/QOXWKCOUzcFCqTOnWCvbnwkOjs3f7Dpzmw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.49.0.tgz",
+      "integrity": "sha512-bd5/ZJlNIX25n83mvcCh9eYQiDdf6gLHNH6ZftA/EbFfkE0o/qHrFhBhiB9HBY9ZoHhtoqrJNv5W9qKFHx1EIA==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.49.0",
+        "@aws-sdk/credential-provider-imds": "3.49.0",
+        "@aws-sdk/node-config-provider": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.49.0.tgz",
+      "integrity": "sha512-ZbPu8Dd3Qm0BMP71FWUH7KPpZA/6izfkDlxbvHxtHdW7XYZALuJ0cVRpWGIY2fCSuA9X8Jfn60KMyjuSAuzM1w==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.49.0.tgz",
+      "integrity": "sha512-ryw+t+quF1raaK0nXSplMiCVnahNLNgNDijZCFFkddGTMaCy+L4VRLYyNms3bgwt3G0BmVn9f3uyDWRSkn5sSg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.49.0.tgz",
+      "integrity": "sha512-NH7iQUYvijYZEOzZkF/QQrp8kBOA9H0Z89hR/63FDCjr1M0Cdcs1bLaFO0a0qbW9NQtoYNsMBMk7pTveDrAzTw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.49.0.tgz",
+      "integrity": "sha512-RR4E6WlDSu9SivPjx/Jddo87PeVg6dhRL0XGdDBpew7i8bfwqCvxQydkbWIetxucLrt9zII9QnLDQUPBue1xUw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.49.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.49.0.tgz",
+      "integrity": "sha512-ixUkF6kcDfsWO0kivyOKAnBITJm7InGa04ALbgAfuuE7RU1cVkXVMFIn5vux7QkziK7+JwozM9SNPIwNukElDw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.49.0.tgz",
+      "integrity": "sha512-u9ZgAiTWX9yZFQ/ptlnVpYJ/rXF7aE2Wagar1IjhZrnxXbpVJvcX1EeRayxI1P5AAp2y2fiEKHZzX9ugTwOcEg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.49.0.tgz",
+      "integrity": "sha512-QTF5b5OT2y6xsQl8sDiiXqg2n/VtgqFA+tP3WMooOSFd/ZFBbT6HoiSHXHMeTjpB/L9ZT+eUaCoBz8Jq09lBDg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "node_modules/commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.1.tgz",
+      "integrity": "sha512-P4Af7E2iJqZN2HYMdWINEg++OC2CtP1ygTx6WQCzZISQA+i3Q+K3E8S8t/PSYqUnvtfh5XVjbFT9uA+4IT8C2w==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.1",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.1",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
+          "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+          "requires": {
+            "@aws-crypto/util": "^2.0.1",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.49.0.tgz",
+      "integrity": "sha512-1qLlgOgg3yrtm+AJEP7yoIk90o6ns3Dia8S9DRjj29jY40446etH3v/tIbHPE+em69HLXl1K6e5KD6t7EDxnlg==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.49.0.tgz",
+      "integrity": "sha512-rY8uZo4DeNwwKf+Sx0TX/5ysXJKf+0SQSCTWD9S4a0AjtiaLc6hKCX+sJY43VDHvNYieKtXLDYHBdhhqZKwG+g==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.49.0",
+        "@aws-sdk/fetch-http-handler": "3.49.0",
+        "@aws-sdk/hash-node": "3.49.0",
+        "@aws-sdk/invalid-dependency": "3.49.0",
+        "@aws-sdk/middleware-content-length": "3.49.0",
+        "@aws-sdk/middleware-host-header": "3.49.0",
+        "@aws-sdk/middleware-logger": "3.49.0",
+        "@aws-sdk/middleware-retry": "3.49.0",
+        "@aws-sdk/middleware-serde": "3.49.0",
+        "@aws-sdk/middleware-stack": "3.49.0",
+        "@aws-sdk/middleware-user-agent": "3.49.0",
+        "@aws-sdk/node-config-provider": "3.49.0",
+        "@aws-sdk/node-http-handler": "3.49.0",
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/smithy-client": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/url-parser": "3.49.0",
+        "@aws-sdk/util-base64-browser": "3.49.0",
+        "@aws-sdk/util-base64-node": "3.49.0",
+        "@aws-sdk/util-body-length-browser": "3.49.0",
+        "@aws-sdk/util-body-length-node": "3.49.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.49.0",
+        "@aws-sdk/util-defaults-mode-node": "3.49.0",
+        "@aws-sdk/util-user-agent-browser": "3.49.0",
+        "@aws-sdk/util-user-agent-node": "3.49.0",
+        "@aws-sdk/util-utf8-browser": "3.49.0",
+        "@aws-sdk/util-utf8-node": "3.49.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-browser": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+          "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^2.0.0",
+            "@aws-crypto/sha256-js": "^2.0.0",
+            "@aws-crypto/supports-web-crypto": "^2.0.0",
+            "@aws-crypto/util": "^2.0.0",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.49.0.tgz",
+      "integrity": "sha512-4kYV+89E9MG+/wfPY3dmwqzquQxNd951jdfjQbSg1ii68X/owqmWda4bLulV0Z4iGUz9TXkbaJCWyRyjsFNe4w==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-config-provider": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.49.0.tgz",
+      "integrity": "sha512-mx82N0un6URmmiM11X3ObK3ka5R99lEFdhwPc0jqsCPnXRVioUtK5DXkJ8FmgixbDcs5Pdij9A8MINSeBrG0bQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.49.0.tgz",
+      "integrity": "sha512-d/H5VgmRiIupQdPg9QcX16kdvuiS/YytRYCQOncVstNXHvYZM9EgeIXJLXyPNaD2W8SS7CBf4KKWYJn3V+9AZw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/url-parser": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.49.0.tgz",
+      "integrity": "sha512-QlWfxDwZVyX36pghgkKGBR+fBmX/mjmvc0kzxUmqGhUYAkDQ0YKR11ybpGBrxBKT4lIOE+9z6Tu4nLjp3OlJIg==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.49.0",
+        "@aws-sdk/credential-provider-imds": "3.49.0",
+        "@aws-sdk/credential-provider-sso": "3.49.0",
+        "@aws-sdk/credential-provider-web-identity": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-credentials": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.49.0.tgz",
+      "integrity": "sha512-DonoqOZHcqfNuwMG1fGJpHJTqf1QinihRKzlOoUWzmseqBCiuagGouSN7nOQgee5BrzF0X9/nao9lnPc4on2TA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.49.0",
+        "@aws-sdk/credential-provider-imds": "3.49.0",
+        "@aws-sdk/credential-provider-ini": "3.49.0",
+        "@aws-sdk/credential-provider-process": "3.49.0",
+        "@aws-sdk/credential-provider-sso": "3.49.0",
+        "@aws-sdk/credential-provider-web-identity": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-credentials": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.49.0.tgz",
+      "integrity": "sha512-Zn7CJHoXln8O+yBKdTBvcwCz6GDh48s7HtIsqjoOrqoL0oZWhgy8gn8S9KQ+HIqpiO8N0lMMteXuPl5fbC2zGg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-credentials": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.49.0.tgz",
+      "integrity": "sha512-sFTqbQOyGR88K10Y1OgauEPKDmEibxtAkLSFjkJ6Yw/Jyp+lftchoa+TxRrNvDY1zjZX+XauVI6UmD5Pi4E1NQ==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-credentials": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.49.0.tgz",
+      "integrity": "sha512-mlIHUTn04unB0HEwEO12YIY5848uE9B+gYI+YwlNZ70KXGs3lj2horOgPgbxeIfulCVw0aRTKChUg2ActTosYg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.49.0.tgz",
+      "integrity": "sha512-ougJRsvoIGP0qTgHSGVF1B5Ui95Y/SP5CpY/y6B8vMGrwJ+MmvcCUE3Qd2UJGjO1PfUneno8PHK4u5x7hc2ceA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/querystring-builder": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-base64-browser": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.49.0.tgz",
+      "integrity": "sha512-nRNCmSkcJOzWzKU6NihlKW/6H1HxaaBjUe9ETnwWIgwPC7NZ6IWtri48Cf7Itvveu3dln3ZM2WSXN20TlQpuBw==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-buffer-from": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.49.0.tgz",
+      "integrity": "sha512-MXf/9l/Oiy+KGKDvInv0RT4rtS+iNftYRTlTmUn3RR74Kz8Fvw+O0RcUjzSrNn5SpjCf/UsGrF+KBTm2gFYQCA==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.49.0.tgz",
+      "integrity": "sha512-tLba+xvlm1+aAnv+bGieVZo8DCENbqfS9kLf/hp+9hrUSiNAsxs9Pqi34JBpMKGn6h9qORp6f8ClRS+gK8yvWg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.49.0.tgz",
+      "integrity": "sha512-7IaghPT7X92gNoyn9LzZj4V5YpGPDCYQTWhpzZoIlw88vOR4I0zKg7jwYeElRoNfRCI4OYhF26ajKnNHzNMlbA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.49.0.tgz",
+      "integrity": "sha512-5l1ILqHs2mGqNvJb5mRe7hHbTQOO292jghE/LItpNx2tiu7BBGzP1bslHcyEVYoRBX9Oqyfou7s9Ww2yBWtImQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.49.0.tgz",
+      "integrity": "sha512-OicQ0w5sCJXgpeZ+t3XeJA2R/09YfuSe53Ma6aWZm/2/r8vG/SW0yAnwFvwJeCm3DKtBxU1qO2eWhFqvJuWRVA==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.49.0.tgz",
+      "integrity": "sha512-RSS4R4PNULHA1b1eYR50YPPfOV2jRuXgLNLVVYMEzzC23MabKEXJYPge+pI1Q9rRrbahVj7aQcOTSpT0MsiEeA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/service-error-classification": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.49.0.tgz",
+      "integrity": "sha512-bMAlwR19uFUZ4om+U+/vnPvkcyYw83HdtERF9wrjAqNUnqYsifA0xn4R7Sakg6CW8V0h82dsST6zVfmHd+E2VA==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.49.0.tgz",
+      "integrity": "sha512-OZxs2P7EH58gkvkTI7ESlUPGam0TkE0ZxOX35KjCOcYMuWvTMshKBzHRLX64nz3DYdaHSIGHgB1v8LKELZjltw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.49.0.tgz",
+      "integrity": "sha512-uAcKgafZ12L8UnyeQGgSFtwOKUfiBWDLt4P2fEHvZRz/HAIcK4pu1PXPArjwteinhUiCDNFfPw8hAPvstMoG6w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.49.0.tgz",
+      "integrity": "sha512-OCn5c6M/RJDEO80Q+Iy4ADSYgqd/uyEsvp+7lU4di4bMND9kYT4JO2ky2SWjIuARGq/mhMOhaN2DO9MbcqV20g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.49.0.tgz",
+      "integrity": "sha512-t7D9hoSigBihC9RRgYrkzgSER0fYzZe7192pJAaP6jk13ZOpccQRfXZoKge/cm42aHJsTy8DdQdGtLg7wLTp0g==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.49.0",
+        "@aws-sdk/protocol-http": "3.49.0",
+        "@aws-sdk/querystring-builder": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.49.0.tgz",
+      "integrity": "sha512-6D48YpriOUpniezVuRI8J+MG+vgwb5C1SzBdgN4+S6DqbsEZy+kdEubXdoMICEd+Z8h7lH3p5zMr6po0icGCfA==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.49.0.tgz",
+      "integrity": "sha512-lb9CO7/vm26v4UwveWb4jSapqWWP/p0b9SuHpRExq+yMuvHqwxcoGrxmvS7FsanWbepRF1895dxU/Ar6/4pviA==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.49.0.tgz",
+      "integrity": "sha512-+NlgIYihVyUetZcrF1ADY0eg8WW1/ETD5bzTwguTiKduXVHmavSakXK1jJF5vg05mefljToZXjQnOaEs9+K9LA==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-uri-escape": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.49.0.tgz",
+      "integrity": "sha512-4bSCHI5A8wi+JjsD1gAhMuGRGjDmlw6MoMWUiv4R2J8Ow/9mV8biKRo2ZytUPiSSu4G5JQ7mEkqFsm/VgkstDQ==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.49.0.tgz",
+      "integrity": "sha512-iVmf7RcrIsM/We5ip8fe14RzEpSLF5eN8oqhCMftEdmMVnOYMd/9x0f1w69fbyBJNIIpyREqM8eAKz5OWQn5/g=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.49.0.tgz",
+      "integrity": "sha512-TcgKU6U/3JZpenRFhGSy5R5QsBWkYoeawTK1rTK6deu3UbxVwtOkietbfwP3kIwKZ4hz6OkNeHcOJtXX/InZKw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.49.0.tgz",
+      "integrity": "sha512-mQSGclWmv/9/MsgthBuKMHN6nkkhGTLXspkhqJ9xSUhjhoaHQVwMoJc39PowJGbYFn1AtCvHAqJtFXTGsMRwPA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/util-hex-encoding": "3.49.0",
+        "@aws-sdk/util-uri-escape": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.49.0.tgz",
+      "integrity": "sha512-ANh9SlEvuru1DcalVoQ7K6wSCYuw4jyeTsIDsJSa13ckrmXAg+ql9vq61ELAXTSNVmuAISuuPjbVaWvOYCtdCQ==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.49.0.tgz",
+      "integrity": "sha512-8bCqEpquTlPN6xkjaJ+s+RoEFIu5r4G8oXOsQ5HYBvBdpx62HnCqzHLFNHycL2b8sE+VysQgNvmdQYR98vdMGQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.49.0.tgz",
+      "integrity": "sha512-l5td6eu+sIjzNsZYVGr7Mz6vssf2j/8/QrrTYF76J2R6OoceCsKdyJgJPP/tXBdcp4HUZDdVcMqtWRbxGC4izQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.49.0.tgz",
+      "integrity": "sha512-HFXJbsJC6AfrnO9M8KuFDo4ihvLbCbCFCfpWy0Gs4t8kTcvGqH8fIpfVsQKAtFHMmb8fen2LduOk+NNSA7srYw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.49.0.tgz",
+      "integrity": "sha512-xFAzOLZJOEZipG3KVLjB5z1g5PJSi6cmZOGWg2NC2/H5N0/Z+e5ObnIH8mpfO1d6kWchUuo3qJ6fTOvg/ynw7A==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.49.0.tgz",
+      "integrity": "sha512-4a9Bw33JGKefaZDORlosQRMKxJGEYEiDD5kgNvwIv+KRl5yj2unePia6aFWMqXTWqidOb9WVlqc0Lh73ei5pTg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.49.0.tgz",
+      "integrity": "sha512-ME5Sc8jo9BzToUjWskQKZM/NqN9PpwRDTOSH6EISDBUiH5bhWfY8MLkZqIN2UZz/XOiV3yOeWAU+fMYNnGdAQQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.49.0.tgz",
+      "integrity": "sha512-8JbIPYn91f+16QpDk000PdIBlBZu8/SoL1nF2fpAJ+M98jXpKUws3oiCztJ2FPIKRe/3ikKuZM4HxWrDyJa40Q==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.49.0.tgz",
+      "integrity": "sha512-oVGT9q9UIGdv9Cra4B51QNciWKYQXTlfh8oD2FgLp91NbGTIkQLvK7Pah4TbBoa5+0u/obBI07UwCVn7wphWBQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-credentials": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.49.0.tgz",
+      "integrity": "sha512-RzbKeuylb56m0zPuLGl5/TkN07+c4PKhZu3hikpsvN8n8n7aFHWPUus63QEGgVaUMCZD0QV6HqJfsCVVFF7UIg==",
+      "requires": {
+        "@aws-sdk/shared-ini-file-loader": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.49.0.tgz",
+      "integrity": "sha512-MNOvFET5TNBHgvsmfcLuxVDDUV0OIjE1lxrdbXWol7bMgLc2uL3/QOXWKCOUzcFCqTOnWCvbnwkOjs3f7Dpzmw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.49.0.tgz",
+      "integrity": "sha512-bd5/ZJlNIX25n83mvcCh9eYQiDdf6gLHNH6ZftA/EbFfkE0o/qHrFhBhiB9HBY9ZoHhtoqrJNv5W9qKFHx1EIA==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.49.0",
+        "@aws-sdk/credential-provider-imds": "3.49.0",
+        "@aws-sdk/node-config-provider": "3.49.0",
+        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.49.0.tgz",
+      "integrity": "sha512-ZbPu8Dd3Qm0BMP71FWUH7KPpZA/6izfkDlxbvHxtHdW7XYZALuJ0cVRpWGIY2fCSuA9X8Jfn60KMyjuSAuzM1w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.49.0.tgz",
+      "integrity": "sha512-ryw+t+quF1raaK0nXSplMiCVnahNLNgNDijZCFFkddGTMaCy+L4VRLYyNms3bgwt3G0BmVn9f3uyDWRSkn5sSg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.49.0.tgz",
+      "integrity": "sha512-NH7iQUYvijYZEOzZkF/QQrp8kBOA9H0Z89hR/63FDCjr1M0Cdcs1bLaFO0a0qbW9NQtoYNsMBMk7pTveDrAzTw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.49.0.tgz",
+      "integrity": "sha512-RR4E6WlDSu9SivPjx/Jddo87PeVg6dhRL0XGdDBpew7i8bfwqCvxQydkbWIetxucLrt9zII9QnLDQUPBue1xUw==",
+      "requires": {
+        "@aws-sdk/types": "3.49.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.49.0.tgz",
+      "integrity": "sha512-ixUkF6kcDfsWO0kivyOKAnBITJm7InGa04ALbgAfuuE7RU1cVkXVMFIn5vux7QkziK7+JwozM9SNPIwNukElDw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.49.0",
+        "@aws-sdk/types": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.49.0.tgz",
+      "integrity": "sha512-u9ZgAiTWX9yZFQ/ptlnVpYJ/rXF7aE2Wagar1IjhZrnxXbpVJvcX1EeRayxI1P5AAp2y2fiEKHZzX9ugTwOcEg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.49.0.tgz",
+      "integrity": "sha512-QTF5b5OT2y6xsQl8sDiiXqg2n/VtgqFA+tP3WMooOSFd/ZFBbT6HoiSHXHMeTjpB/L9ZT+eUaCoBz8Jq09lBDg==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.49.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/arxlive_spotlight_annotation/package.json
+++ b/arxlive_spotlight_annotation/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dap_dv_backends",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nestauk/dap_dv_backends.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/nestauk/dap_dv_backends/issues"
+  },
+  "homepage": "https://github.com/nestauk/dap_dv_backends#readme",
+  "dependencies": {
+    "@aws-crypto/sha256-browser": "^2.0.1",
+    "@aws-sdk/credential-provider-node": "^3.49.0",
+    "@aws-sdk/node-http-handler": "^3.49.0",
+    "@aws-sdk/protocol-http": "^3.49.0",
+    "@aws-sdk/signature-v4": "^3.49.0",
+    "commander": "^9.0.0"
+  }
+}

--- a/arxlive_spotlight_annotation/src/bin/es/snapshot.mjs
+++ b/arxlive_spotlight_annotation/src/bin/es/snapshot.mjs
@@ -1,0 +1,89 @@
+import { Command } from 'commander';
+
+import { buildRequest, makeRequest } from 'es/requests.mjs';
+
+const settings = {
+	region: 'eu-west-2',
+	bucketName: 'nesta-datavis-arxlive-copy-snapshot',
+	snapshotRole: 'arxliveSnapshotRole',
+	repository: 'datavis-arxlive-snapshot',
+	awsID: '195787726158',
+};
+
+const program = new Command();
+
+program
+	.command('register')
+	.description('Registers new snapshot repository')
+	.argument('<domain>', 'domain on which to register snapshot')
+	.argument('<repository>', 'repository name')
+	.action(async (domain, repository) => {
+		const path = `_snapshot/${repository}`;
+		const payload = {
+			type: 's3',
+			settings: {
+				bucket: settings.bucketName,
+				region: settings.region,
+				role_arn: `arn:aws:iam::${settings.awsID}:role/${settings.snapshotRole}`,
+			},
+		};
+		const request = makeRequest(domain, path, 'PUT', payload);
+		await makeRequest(request, { verbose: true });
+	});
+
+program
+	.command('trigger')
+	.description(
+		'Triggers a manual snapshot given the settings and the input snapshot name'
+	)
+	.argument('<domain>', 'domain on which to trigger snapshot')
+	.argument('<repository>', 'repository name')
+	.argument('<snapshot>', 'snapshot name')
+	.action(async (domain, repository, snapshot) => {
+		const path = `_snapshot/${repository}/${snapshot}`;
+		const request = buildRequest(domain, path, 'PUT');
+		await makeRequest(request, { verbose: true });
+	});
+
+program
+	.command('ls')
+	.description('Lists repositories or snapshots for a given repository')
+	.argument(
+		'<domain>',
+		'the domain for which to list snapshots or repositories'
+	)
+	.argument('[repository]', 'the repository for which to list snapshots')
+	.action(async (domain, repository) => {
+		const path = repository ? `_snapshot/${repository}/_all` : '_snapshot';
+		const request = buildRequest(domain, path, 'GET');
+		await makeRequest(request, { verbose: true });
+	});
+
+program
+	.command('restore')
+	.description(
+		'Restore snapshot to specified domain given in settings in this file'
+	)
+	.argument('<domain>', 'the domain to which to restore')
+	.argument('<repository>', 'repository name')
+	.argument('<snapshot>', 'the ID of the snapshot to copy')
+	.action(async (domain, repository, snapshot) => {
+		const payload = { indices: '-.kibana*,-.opendistro*' };
+		const path = `_snapshot/${repository}/${snapshot}/_restore`;
+		const request = buildRequest(domain, path, 'POST', payload);
+
+		await makeRequest(request, { verbose: true });
+		await main(path, 'POST', settings.newDomain, JSON.stringify(payload));
+	});
+
+program
+	.command('status')
+	.description('Gives the snapshot status for the supplied ES domain')
+	.argument('<domain>', 'domain for which to give the status')
+	.action(async domain => {
+		const path = '_snapshot/_status';
+		const request = buildRequest(domain, path, 'GET');
+		await makeRequest(request, { verbose: true });
+	});
+
+program.parse();


### PR DESCRIPTION
This PR introduces a script which allows signed HTTP requests to access
the ElasticSearch snapshot API. The script, located at
src/bin/es/snapshot.mjs, can list the status of snapshots and snapshot
repositories, create new snapshots and snapshot repositories, and
trigger manual snapshots. For this, the user must have the relevant
AWS credentials (access key and secret key).

The PR also intends to Document that this process has been undertaken
using the aforementioned script, and the new domain is available
here: https://search-datavis-arxlive-copy-n6ltva3lqh7x7xb6ucpaqfb5a4.eu-west-2.es.amazonaws.com

closes #1