### PR TITLE
Annotate arXiv items with DBpedia entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+logs
 node_modules
 !/**/src/node_modules
 .prettierignore

--- a/arxlive_spotlight_annotation/package-lock.json
+++ b/arxlive_spotlight_annotation/package-lock.json
@@ -1,1439 +1,2134 @@
 {
-  "name": "dap_dv_backends",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "dap_dv_backends",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "^2.0.1",
-        "@aws-sdk/credential-provider-node": "^3.49.0",
-        "@aws-sdk/node-http-handler": "^3.49.0",
-        "@aws-sdk/protocol-http": "^3.49.0",
-        "@aws-sdk/signature-v4": "^3.49.0",
-        "commander": "^9.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.1.tgz",
-      "integrity": "sha512-P4Af7E2iJqZN2HYMdWINEg++OC2CtP1ygTx6WQCzZISQA+i3Q+K3E8S8t/PSYqUnvtfh5XVjbFT9uA+4IT8C2w==",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.1",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.1",
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
-      "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
-      "dependencies": {
-        "@aws-crypto/util": "^2.0.1",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.49.0.tgz",
-      "integrity": "sha512-1qLlgOgg3yrtm+AJEP7yoIk90o6ns3Dia8S9DRjj29jY40446etH3v/tIbHPE+em69HLXl1K6e5KD6t7EDxnlg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.49.0.tgz",
-      "integrity": "sha512-rY8uZo4DeNwwKf+Sx0TX/5ysXJKf+0SQSCTWD9S4a0AjtiaLc6hKCX+sJY43VDHvNYieKtXLDYHBdhhqZKwG+g==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.49.0",
-        "@aws-sdk/fetch-http-handler": "3.49.0",
-        "@aws-sdk/hash-node": "3.49.0",
-        "@aws-sdk/invalid-dependency": "3.49.0",
-        "@aws-sdk/middleware-content-length": "3.49.0",
-        "@aws-sdk/middleware-host-header": "3.49.0",
-        "@aws-sdk/middleware-logger": "3.49.0",
-        "@aws-sdk/middleware-retry": "3.49.0",
-        "@aws-sdk/middleware-serde": "3.49.0",
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/middleware-user-agent": "3.49.0",
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/node-http-handler": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/smithy-client": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/url-parser": "3.49.0",
-        "@aws-sdk/util-base64-browser": "3.49.0",
-        "@aws-sdk/util-base64-node": "3.49.0",
-        "@aws-sdk/util-body-length-browser": "3.49.0",
-        "@aws-sdk/util-body-length-node": "3.49.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.49.0",
-        "@aws-sdk/util-defaults-mode-node": "3.49.0",
-        "@aws-sdk/util-user-agent-browser": "3.49.0",
-        "@aws-sdk/util-user-agent-node": "3.49.0",
-        "@aws-sdk/util-utf8-browser": "3.49.0",
-        "@aws-sdk/util-utf8-node": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.49.0.tgz",
-      "integrity": "sha512-4kYV+89E9MG+/wfPY3dmwqzquQxNd951jdfjQbSg1ii68X/owqmWda4bLulV0Z4iGUz9TXkbaJCWyRyjsFNe4w==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-config-provider": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.49.0.tgz",
-      "integrity": "sha512-mx82N0un6URmmiM11X3ObK3ka5R99lEFdhwPc0jqsCPnXRVioUtK5DXkJ8FmgixbDcs5Pdij9A8MINSeBrG0bQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.49.0.tgz",
-      "integrity": "sha512-d/H5VgmRiIupQdPg9QcX16kdvuiS/YytRYCQOncVstNXHvYZM9EgeIXJLXyPNaD2W8SS7CBf4KKWYJn3V+9AZw==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/url-parser": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.49.0.tgz",
-      "integrity": "sha512-QlWfxDwZVyX36pghgkKGBR+fBmX/mjmvc0kzxUmqGhUYAkDQ0YKR11ybpGBrxBKT4lIOE+9z6Tu4nLjp3OlJIg==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/credential-provider-sso": "3.49.0",
-        "@aws-sdk/credential-provider-web-identity": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-credentials": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.49.0.tgz",
-      "integrity": "sha512-DonoqOZHcqfNuwMG1fGJpHJTqf1QinihRKzlOoUWzmseqBCiuagGouSN7nOQgee5BrzF0X9/nao9lnPc4on2TA==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/credential-provider-ini": "3.49.0",
-        "@aws-sdk/credential-provider-process": "3.49.0",
-        "@aws-sdk/credential-provider-sso": "3.49.0",
-        "@aws-sdk/credential-provider-web-identity": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-credentials": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.49.0.tgz",
-      "integrity": "sha512-Zn7CJHoXln8O+yBKdTBvcwCz6GDh48s7HtIsqjoOrqoL0oZWhgy8gn8S9KQ+HIqpiO8N0lMMteXuPl5fbC2zGg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-credentials": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.49.0.tgz",
-      "integrity": "sha512-sFTqbQOyGR88K10Y1OgauEPKDmEibxtAkLSFjkJ6Yw/Jyp+lftchoa+TxRrNvDY1zjZX+XauVI6UmD5Pi4E1NQ==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-credentials": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.49.0.tgz",
-      "integrity": "sha512-mlIHUTn04unB0HEwEO12YIY5848uE9B+gYI+YwlNZ70KXGs3lj2horOgPgbxeIfulCVw0aRTKChUg2ActTosYg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.49.0.tgz",
-      "integrity": "sha512-ougJRsvoIGP0qTgHSGVF1B5Ui95Y/SP5CpY/y6B8vMGrwJ+MmvcCUE3Qd2UJGjO1PfUneno8PHK4u5x7hc2ceA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/querystring-builder": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-base64-browser": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.49.0.tgz",
-      "integrity": "sha512-nRNCmSkcJOzWzKU6NihlKW/6H1HxaaBjUe9ETnwWIgwPC7NZ6IWtri48Cf7Itvveu3dln3ZM2WSXN20TlQpuBw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-buffer-from": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.49.0.tgz",
-      "integrity": "sha512-MXf/9l/Oiy+KGKDvInv0RT4rtS+iNftYRTlTmUn3RR74Kz8Fvw+O0RcUjzSrNn5SpjCf/UsGrF+KBTm2gFYQCA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.49.0.tgz",
-      "integrity": "sha512-tLba+xvlm1+aAnv+bGieVZo8DCENbqfS9kLf/hp+9hrUSiNAsxs9Pqi34JBpMKGn6h9qORp6f8ClRS+gK8yvWg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.49.0.tgz",
-      "integrity": "sha512-7IaghPT7X92gNoyn9LzZj4V5YpGPDCYQTWhpzZoIlw88vOR4I0zKg7jwYeElRoNfRCI4OYhF26ajKnNHzNMlbA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.49.0.tgz",
-      "integrity": "sha512-5l1ILqHs2mGqNvJb5mRe7hHbTQOO292jghE/LItpNx2tiu7BBGzP1bslHcyEVYoRBX9Oqyfou7s9Ww2yBWtImQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.49.0.tgz",
-      "integrity": "sha512-OicQ0w5sCJXgpeZ+t3XeJA2R/09YfuSe53Ma6aWZm/2/r8vG/SW0yAnwFvwJeCm3DKtBxU1qO2eWhFqvJuWRVA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.49.0.tgz",
-      "integrity": "sha512-RSS4R4PNULHA1b1eYR50YPPfOV2jRuXgLNLVVYMEzzC23MabKEXJYPge+pI1Q9rRrbahVj7aQcOTSpT0MsiEeA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/service-error-classification": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.49.0.tgz",
-      "integrity": "sha512-bMAlwR19uFUZ4om+U+/vnPvkcyYw83HdtERF9wrjAqNUnqYsifA0xn4R7Sakg6CW8V0h82dsST6zVfmHd+E2VA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.49.0.tgz",
-      "integrity": "sha512-OZxs2P7EH58gkvkTI7ESlUPGam0TkE0ZxOX35KjCOcYMuWvTMshKBzHRLX64nz3DYdaHSIGHgB1v8LKELZjltw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.49.0.tgz",
-      "integrity": "sha512-uAcKgafZ12L8UnyeQGgSFtwOKUfiBWDLt4P2fEHvZRz/HAIcK4pu1PXPArjwteinhUiCDNFfPw8hAPvstMoG6w==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.49.0.tgz",
-      "integrity": "sha512-OCn5c6M/RJDEO80Q+Iy4ADSYgqd/uyEsvp+7lU4di4bMND9kYT4JO2ky2SWjIuARGq/mhMOhaN2DO9MbcqV20g==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.49.0.tgz",
-      "integrity": "sha512-t7D9hoSigBihC9RRgYrkzgSER0fYzZe7192pJAaP6jk13ZOpccQRfXZoKge/cm42aHJsTy8DdQdGtLg7wLTp0g==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/querystring-builder": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.49.0.tgz",
-      "integrity": "sha512-6D48YpriOUpniezVuRI8J+MG+vgwb5C1SzBdgN4+S6DqbsEZy+kdEubXdoMICEd+Z8h7lH3p5zMr6po0icGCfA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.49.0.tgz",
-      "integrity": "sha512-lb9CO7/vm26v4UwveWb4jSapqWWP/p0b9SuHpRExq+yMuvHqwxcoGrxmvS7FsanWbepRF1895dxU/Ar6/4pviA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.49.0.tgz",
-      "integrity": "sha512-+NlgIYihVyUetZcrF1ADY0eg8WW1/ETD5bzTwguTiKduXVHmavSakXK1jJF5vg05mefljToZXjQnOaEs9+K9LA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-uri-escape": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.49.0.tgz",
-      "integrity": "sha512-4bSCHI5A8wi+JjsD1gAhMuGRGjDmlw6MoMWUiv4R2J8Ow/9mV8biKRo2ZytUPiSSu4G5JQ7mEkqFsm/VgkstDQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.49.0.tgz",
-      "integrity": "sha512-iVmf7RcrIsM/We5ip8fe14RzEpSLF5eN8oqhCMftEdmMVnOYMd/9x0f1w69fbyBJNIIpyREqM8eAKz5OWQn5/g==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.49.0.tgz",
-      "integrity": "sha512-TcgKU6U/3JZpenRFhGSy5R5QsBWkYoeawTK1rTK6deu3UbxVwtOkietbfwP3kIwKZ4hz6OkNeHcOJtXX/InZKw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.49.0.tgz",
-      "integrity": "sha512-mQSGclWmv/9/MsgthBuKMHN6nkkhGTLXspkhqJ9xSUhjhoaHQVwMoJc39PowJGbYFn1AtCvHAqJtFXTGsMRwPA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-hex-encoding": "3.49.0",
-        "@aws-sdk/util-uri-escape": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.49.0.tgz",
-      "integrity": "sha512-ANh9SlEvuru1DcalVoQ7K6wSCYuw4jyeTsIDsJSa13ckrmXAg+ql9vq61ELAXTSNVmuAISuuPjbVaWvOYCtdCQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.49.0.tgz",
-      "integrity": "sha512-8bCqEpquTlPN6xkjaJ+s+RoEFIu5r4G8oXOsQ5HYBvBdpx62HnCqzHLFNHycL2b8sE+VysQgNvmdQYR98vdMGQ==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.49.0.tgz",
-      "integrity": "sha512-l5td6eu+sIjzNsZYVGr7Mz6vssf2j/8/QrrTYF76J2R6OoceCsKdyJgJPP/tXBdcp4HUZDdVcMqtWRbxGC4izQ==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.49.0.tgz",
-      "integrity": "sha512-HFXJbsJC6AfrnO9M8KuFDo4ihvLbCbCFCfpWy0Gs4t8kTcvGqH8fIpfVsQKAtFHMmb8fen2LduOk+NNSA7srYw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.49.0.tgz",
-      "integrity": "sha512-xFAzOLZJOEZipG3KVLjB5z1g5PJSi6cmZOGWg2NC2/H5N0/Z+e5ObnIH8mpfO1d6kWchUuo3qJ6fTOvg/ynw7A==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.49.0.tgz",
-      "integrity": "sha512-4a9Bw33JGKefaZDORlosQRMKxJGEYEiDD5kgNvwIv+KRl5yj2unePia6aFWMqXTWqidOb9WVlqc0Lh73ei5pTg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.49.0.tgz",
-      "integrity": "sha512-ME5Sc8jo9BzToUjWskQKZM/NqN9PpwRDTOSH6EISDBUiH5bhWfY8MLkZqIN2UZz/XOiV3yOeWAU+fMYNnGdAQQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.49.0.tgz",
-      "integrity": "sha512-8JbIPYn91f+16QpDk000PdIBlBZu8/SoL1nF2fpAJ+M98jXpKUws3oiCztJ2FPIKRe/3ikKuZM4HxWrDyJa40Q==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.49.0.tgz",
-      "integrity": "sha512-oVGT9q9UIGdv9Cra4B51QNciWKYQXTlfh8oD2FgLp91NbGTIkQLvK7Pah4TbBoa5+0u/obBI07UwCVn7wphWBQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-credentials": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.49.0.tgz",
-      "integrity": "sha512-RzbKeuylb56m0zPuLGl5/TkN07+c4PKhZu3hikpsvN8n8n7aFHWPUus63QEGgVaUMCZD0QV6HqJfsCVVFF7UIg==",
-      "dependencies": {
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.49.0.tgz",
-      "integrity": "sha512-MNOvFET5TNBHgvsmfcLuxVDDUV0OIjE1lxrdbXWol7bMgLc2uL3/QOXWKCOUzcFCqTOnWCvbnwkOjs3f7Dpzmw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.49.0.tgz",
-      "integrity": "sha512-bd5/ZJlNIX25n83mvcCh9eYQiDdf6gLHNH6ZftA/EbFfkE0o/qHrFhBhiB9HBY9ZoHhtoqrJNv5W9qKFHx1EIA==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.49.0.tgz",
-      "integrity": "sha512-ZbPu8Dd3Qm0BMP71FWUH7KPpZA/6izfkDlxbvHxtHdW7XYZALuJ0cVRpWGIY2fCSuA9X8Jfn60KMyjuSAuzM1w==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.49.0.tgz",
-      "integrity": "sha512-ryw+t+quF1raaK0nXSplMiCVnahNLNgNDijZCFFkddGTMaCy+L4VRLYyNms3bgwt3G0BmVn9f3uyDWRSkn5sSg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.49.0.tgz",
-      "integrity": "sha512-NH7iQUYvijYZEOzZkF/QQrp8kBOA9H0Z89hR/63FDCjr1M0Cdcs1bLaFO0a0qbW9NQtoYNsMBMk7pTveDrAzTw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.49.0.tgz",
-      "integrity": "sha512-RR4E6WlDSu9SivPjx/Jddo87PeVg6dhRL0XGdDBpew7i8bfwqCvxQydkbWIetxucLrt9zII9QnLDQUPBue1xUw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.49.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.49.0.tgz",
-      "integrity": "sha512-ixUkF6kcDfsWO0kivyOKAnBITJm7InGa04ALbgAfuuE7RU1cVkXVMFIn5vux7QkziK7+JwozM9SNPIwNukElDw==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.49.0.tgz",
-      "integrity": "sha512-u9ZgAiTWX9yZFQ/ptlnVpYJ/rXF7aE2Wagar1IjhZrnxXbpVJvcX1EeRayxI1P5AAp2y2fiEKHZzX9ugTwOcEg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.49.0.tgz",
-      "integrity": "sha512-QTF5b5OT2y6xsQl8sDiiXqg2n/VtgqFA+tP3WMooOSFd/ZFBbT6HoiSHXHMeTjpB/L9ZT+eUaCoBz8Jq09lBDg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
-    },
-    "node_modules/commander": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
-      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    }
-  },
-  "dependencies": {
-    "@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/sha256-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.1.tgz",
-      "integrity": "sha512-P4Af7E2iJqZN2HYMdWINEg++OC2CtP1ygTx6WQCzZISQA+i3Q+K3E8S8t/PSYqUnvtfh5XVjbFT9uA+4IT8C2w==",
-      "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.1",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.1",
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "@aws-crypto/sha256-js": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
-          "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
-          "requires": {
-            "@aws-crypto/util": "^2.0.1",
-            "@aws-sdk/types": "^3.1.0",
-            "tslib": "^1.11.1"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
-      "requires": {
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.49.0.tgz",
-      "integrity": "sha512-1qLlgOgg3yrtm+AJEP7yoIk90o6ns3Dia8S9DRjj29jY40446etH3v/tIbHPE+em69HLXl1K6e5KD6t7EDxnlg==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/client-sso": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.49.0.tgz",
-      "integrity": "sha512-rY8uZo4DeNwwKf+Sx0TX/5ysXJKf+0SQSCTWD9S4a0AjtiaLc6hKCX+sJY43VDHvNYieKtXLDYHBdhhqZKwG+g==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.49.0",
-        "@aws-sdk/fetch-http-handler": "3.49.0",
-        "@aws-sdk/hash-node": "3.49.0",
-        "@aws-sdk/invalid-dependency": "3.49.0",
-        "@aws-sdk/middleware-content-length": "3.49.0",
-        "@aws-sdk/middleware-host-header": "3.49.0",
-        "@aws-sdk/middleware-logger": "3.49.0",
-        "@aws-sdk/middleware-retry": "3.49.0",
-        "@aws-sdk/middleware-serde": "3.49.0",
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/middleware-user-agent": "3.49.0",
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/node-http-handler": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/smithy-client": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/url-parser": "3.49.0",
-        "@aws-sdk/util-base64-browser": "3.49.0",
-        "@aws-sdk/util-base64-node": "3.49.0",
-        "@aws-sdk/util-body-length-browser": "3.49.0",
-        "@aws-sdk/util-body-length-node": "3.49.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.49.0",
-        "@aws-sdk/util-defaults-mode-node": "3.49.0",
-        "@aws-sdk/util-user-agent-browser": "3.49.0",
-        "@aws-sdk/util-user-agent-node": "3.49.0",
-        "@aws-sdk/util-utf8-browser": "3.49.0",
-        "@aws-sdk/util-utf8-node": "3.49.0",
-        "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "@aws-crypto/sha256-browser": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-          "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-          "requires": {
-            "@aws-crypto/ie11-detection": "^2.0.0",
-            "@aws-crypto/sha256-js": "^2.0.0",
-            "@aws-crypto/supports-web-crypto": "^2.0.0",
-            "@aws-crypto/util": "^2.0.0",
-            "@aws-sdk/types": "^3.1.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        }
-      }
-    },
-    "@aws-sdk/config-resolver": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.49.0.tgz",
-      "integrity": "sha512-4kYV+89E9MG+/wfPY3dmwqzquQxNd951jdfjQbSg1ii68X/owqmWda4bLulV0Z4iGUz9TXkbaJCWyRyjsFNe4w==",
-      "requires": {
-        "@aws-sdk/signature-v4": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-config-provider": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-provider-env": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.49.0.tgz",
-      "integrity": "sha512-mx82N0un6URmmiM11X3ObK3ka5R99lEFdhwPc0jqsCPnXRVioUtK5DXkJ8FmgixbDcs5Pdij9A8MINSeBrG0bQ==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.49.0.tgz",
-      "integrity": "sha512-d/H5VgmRiIupQdPg9QcX16kdvuiS/YytRYCQOncVstNXHvYZM9EgeIXJLXyPNaD2W8SS7CBf4KKWYJn3V+9AZw==",
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/url-parser": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-provider-ini": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.49.0.tgz",
-      "integrity": "sha512-QlWfxDwZVyX36pghgkKGBR+fBmX/mjmvc0kzxUmqGhUYAkDQ0YKR11ybpGBrxBKT4lIOE+9z6Tu4nLjp3OlJIg==",
-      "requires": {
-        "@aws-sdk/credential-provider-env": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/credential-provider-sso": "3.49.0",
-        "@aws-sdk/credential-provider-web-identity": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-credentials": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-provider-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.49.0.tgz",
-      "integrity": "sha512-DonoqOZHcqfNuwMG1fGJpHJTqf1QinihRKzlOoUWzmseqBCiuagGouSN7nOQgee5BrzF0X9/nao9lnPc4on2TA==",
-      "requires": {
-        "@aws-sdk/credential-provider-env": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/credential-provider-ini": "3.49.0",
-        "@aws-sdk/credential-provider-process": "3.49.0",
-        "@aws-sdk/credential-provider-sso": "3.49.0",
-        "@aws-sdk/credential-provider-web-identity": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-credentials": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-provider-process": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.49.0.tgz",
-      "integrity": "sha512-Zn7CJHoXln8O+yBKdTBvcwCz6GDh48s7HtIsqjoOrqoL0oZWhgy8gn8S9KQ+HIqpiO8N0lMMteXuPl5fbC2zGg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-credentials": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-provider-sso": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.49.0.tgz",
-      "integrity": "sha512-sFTqbQOyGR88K10Y1OgauEPKDmEibxtAkLSFjkJ6Yw/Jyp+lftchoa+TxRrNvDY1zjZX+XauVI6UmD5Pi4E1NQ==",
-      "requires": {
-        "@aws-sdk/client-sso": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-credentials": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.49.0.tgz",
-      "integrity": "sha512-mlIHUTn04unB0HEwEO12YIY5848uE9B+gYI+YwlNZ70KXGs3lj2horOgPgbxeIfulCVw0aRTKChUg2ActTosYg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.49.0.tgz",
-      "integrity": "sha512-ougJRsvoIGP0qTgHSGVF1B5Ui95Y/SP5CpY/y6B8vMGrwJ+MmvcCUE3Qd2UJGjO1PfUneno8PHK4u5x7hc2ceA==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/querystring-builder": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-base64-browser": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.49.0.tgz",
-      "integrity": "sha512-nRNCmSkcJOzWzKU6NihlKW/6H1HxaaBjUe9ETnwWIgwPC7NZ6IWtri48Cf7Itvveu3dln3ZM2WSXN20TlQpuBw==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-buffer-from": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.49.0.tgz",
-      "integrity": "sha512-MXf/9l/Oiy+KGKDvInv0RT4rtS+iNftYRTlTmUn3RR74Kz8Fvw+O0RcUjzSrNn5SpjCf/UsGrF+KBTm2gFYQCA==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.49.0.tgz",
-      "integrity": "sha512-tLba+xvlm1+aAnv+bGieVZo8DCENbqfS9kLf/hp+9hrUSiNAsxs9Pqi34JBpMKGn6h9qORp6f8ClRS+gK8yvWg==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.49.0.tgz",
-      "integrity": "sha512-7IaghPT7X92gNoyn9LzZj4V5YpGPDCYQTWhpzZoIlw88vOR4I0zKg7jwYeElRoNfRCI4OYhF26ajKnNHzNMlbA==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/middleware-host-header": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.49.0.tgz",
-      "integrity": "sha512-5l1ILqHs2mGqNvJb5mRe7hHbTQOO292jghE/LItpNx2tiu7BBGzP1bslHcyEVYoRBX9Oqyfou7s9Ww2yBWtImQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/middleware-logger": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.49.0.tgz",
-      "integrity": "sha512-OicQ0w5sCJXgpeZ+t3XeJA2R/09YfuSe53Ma6aWZm/2/r8vG/SW0yAnwFvwJeCm3DKtBxU1qO2eWhFqvJuWRVA==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.49.0.tgz",
-      "integrity": "sha512-RSS4R4PNULHA1b1eYR50YPPfOV2jRuXgLNLVVYMEzzC23MabKEXJYPge+pI1Q9rRrbahVj7aQcOTSpT0MsiEeA==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/service-error-classification": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.49.0.tgz",
-      "integrity": "sha512-bMAlwR19uFUZ4om+U+/vnPvkcyYw83HdtERF9wrjAqNUnqYsifA0xn4R7Sakg6CW8V0h82dsST6zVfmHd+E2VA==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.49.0.tgz",
-      "integrity": "sha512-OZxs2P7EH58gkvkTI7ESlUPGam0TkE0ZxOX35KjCOcYMuWvTMshKBzHRLX64nz3DYdaHSIGHgB1v8LKELZjltw==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/middleware-user-agent": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.49.0.tgz",
-      "integrity": "sha512-uAcKgafZ12L8UnyeQGgSFtwOKUfiBWDLt4P2fEHvZRz/HAIcK4pu1PXPArjwteinhUiCDNFfPw8hAPvstMoG6w==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.49.0.tgz",
-      "integrity": "sha512-OCn5c6M/RJDEO80Q+Iy4ADSYgqd/uyEsvp+7lU4di4bMND9kYT4JO2ky2SWjIuARGq/mhMOhaN2DO9MbcqV20g==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.49.0.tgz",
-      "integrity": "sha512-t7D9hoSigBihC9RRgYrkzgSER0fYzZe7192pJAaP6jk13ZOpccQRfXZoKge/cm42aHJsTy8DdQdGtLg7wLTp0g==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/querystring-builder": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.49.0.tgz",
-      "integrity": "sha512-6D48YpriOUpniezVuRI8J+MG+vgwb5C1SzBdgN4+S6DqbsEZy+kdEubXdoMICEd+Z8h7lH3p5zMr6po0icGCfA==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.49.0.tgz",
-      "integrity": "sha512-lb9CO7/vm26v4UwveWb4jSapqWWP/p0b9SuHpRExq+yMuvHqwxcoGrxmvS7FsanWbepRF1895dxU/Ar6/4pviA==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.49.0.tgz",
-      "integrity": "sha512-+NlgIYihVyUetZcrF1ADY0eg8WW1/ETD5bzTwguTiKduXVHmavSakXK1jJF5vg05mefljToZXjQnOaEs9+K9LA==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-uri-escape": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.49.0.tgz",
-      "integrity": "sha512-4bSCHI5A8wi+JjsD1gAhMuGRGjDmlw6MoMWUiv4R2J8Ow/9mV8biKRo2ZytUPiSSu4G5JQ7mEkqFsm/VgkstDQ==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.49.0.tgz",
-      "integrity": "sha512-iVmf7RcrIsM/We5ip8fe14RzEpSLF5eN8oqhCMftEdmMVnOYMd/9x0f1w69fbyBJNIIpyREqM8eAKz5OWQn5/g=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.49.0.tgz",
-      "integrity": "sha512-TcgKU6U/3JZpenRFhGSy5R5QsBWkYoeawTK1rTK6deu3UbxVwtOkietbfwP3kIwKZ4hz6OkNeHcOJtXX/InZKw==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.49.0.tgz",
-      "integrity": "sha512-mQSGclWmv/9/MsgthBuKMHN6nkkhGTLXspkhqJ9xSUhjhoaHQVwMoJc39PowJGbYFn1AtCvHAqJtFXTGsMRwPA==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-hex-encoding": "3.49.0",
-        "@aws-sdk/util-uri-escape": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.49.0.tgz",
-      "integrity": "sha512-ANh9SlEvuru1DcalVoQ7K6wSCYuw4jyeTsIDsJSa13ckrmXAg+ql9vq61ELAXTSNVmuAISuuPjbVaWvOYCtdCQ==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/types": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.49.0.tgz",
-      "integrity": "sha512-8bCqEpquTlPN6xkjaJ+s+RoEFIu5r4G8oXOsQ5HYBvBdpx62HnCqzHLFNHycL2b8sE+VysQgNvmdQYR98vdMGQ=="
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.49.0.tgz",
-      "integrity": "sha512-l5td6eu+sIjzNsZYVGr7Mz6vssf2j/8/QrrTYF76J2R6OoceCsKdyJgJPP/tXBdcp4HUZDdVcMqtWRbxGC4izQ==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-base64-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.49.0.tgz",
-      "integrity": "sha512-HFXJbsJC6AfrnO9M8KuFDo4ihvLbCbCFCfpWy0Gs4t8kTcvGqH8fIpfVsQKAtFHMmb8fen2LduOk+NNSA7srYw==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-base64-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.49.0.tgz",
-      "integrity": "sha512-xFAzOLZJOEZipG3KVLjB5z1g5PJSi6cmZOGWg2NC2/H5N0/Z+e5ObnIH8mpfO1d6kWchUuo3qJ6fTOvg/ynw7A==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.49.0.tgz",
-      "integrity": "sha512-4a9Bw33JGKefaZDORlosQRMKxJGEYEiDD5kgNvwIv+KRl5yj2unePia6aFWMqXTWqidOb9WVlqc0Lh73ei5pTg==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.49.0.tgz",
-      "integrity": "sha512-ME5Sc8jo9BzToUjWskQKZM/NqN9PpwRDTOSH6EISDBUiH5bhWfY8MLkZqIN2UZz/XOiV3yOeWAU+fMYNnGdAQQ==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.49.0.tgz",
-      "integrity": "sha512-8JbIPYn91f+16QpDk000PdIBlBZu8/SoL1nF2fpAJ+M98jXpKUws3oiCztJ2FPIKRe/3ikKuZM4HxWrDyJa40Q==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.49.0.tgz",
-      "integrity": "sha512-oVGT9q9UIGdv9Cra4B51QNciWKYQXTlfh8oD2FgLp91NbGTIkQLvK7Pah4TbBoa5+0u/obBI07UwCVn7wphWBQ==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-credentials": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.49.0.tgz",
-      "integrity": "sha512-RzbKeuylb56m0zPuLGl5/TkN07+c4PKhZu3hikpsvN8n8n7aFHWPUus63QEGgVaUMCZD0QV6HqJfsCVVFF7UIg==",
-      "requires": {
-        "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.49.0.tgz",
-      "integrity": "sha512-MNOvFET5TNBHgvsmfcLuxVDDUV0OIjE1lxrdbXWol7bMgLc2uL3/QOXWKCOUzcFCqTOnWCvbnwkOjs3f7Dpzmw==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.49.0.tgz",
-      "integrity": "sha512-bd5/ZJlNIX25n83mvcCh9eYQiDdf6gLHNH6ZftA/EbFfkE0o/qHrFhBhiB9HBY9ZoHhtoqrJNv5W9qKFHx1EIA==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.49.0.tgz",
-      "integrity": "sha512-ZbPu8Dd3Qm0BMP71FWUH7KPpZA/6izfkDlxbvHxtHdW7XYZALuJ0cVRpWGIY2fCSuA9X8Jfn60KMyjuSAuzM1w==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-locate-window": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.49.0.tgz",
-      "integrity": "sha512-ryw+t+quF1raaK0nXSplMiCVnahNLNgNDijZCFFkddGTMaCy+L4VRLYyNms3bgwt3G0BmVn9f3uyDWRSkn5sSg==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.49.0.tgz",
-      "integrity": "sha512-NH7iQUYvijYZEOzZkF/QQrp8kBOA9H0Z89hR/63FDCjr1M0Cdcs1bLaFO0a0qbW9NQtoYNsMBMk7pTveDrAzTw==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-user-agent-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.49.0.tgz",
-      "integrity": "sha512-RR4E6WlDSu9SivPjx/Jddo87PeVg6dhRL0XGdDBpew7i8bfwqCvxQydkbWIetxucLrt9zII9QnLDQUPBue1xUw==",
-      "requires": {
-        "@aws-sdk/types": "3.49.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-user-agent-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.49.0.tgz",
-      "integrity": "sha512-ixUkF6kcDfsWO0kivyOKAnBITJm7InGa04ALbgAfuuE7RU1cVkXVMFIn5vux7QkziK7+JwozM9SNPIwNukElDw==",
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-utf8-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.49.0.tgz",
-      "integrity": "sha512-u9ZgAiTWX9yZFQ/ptlnVpYJ/rXF7aE2Wagar1IjhZrnxXbpVJvcX1EeRayxI1P5AAp2y2fiEKHZzX9ugTwOcEg==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.49.0.tgz",
-      "integrity": "sha512-QTF5b5OT2y6xsQl8sDiiXqg2n/VtgqFA+tP3WMooOSFd/ZFBbT6HoiSHXHMeTjpB/L9ZT+eUaCoBz8Jq09lBDg==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.49.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
-    },
-    "commander": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
-      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
-    },
-    "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    }
-  }
+	"name": "arxlive_spotlight_annotation",
+	"version": "0.0.1",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "arxlive_spotlight_annotation",
+			"version": "0.0.1",
+			"license": "ISC",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "^2.0.1",
+				"@aws-sdk/credential-provider-node": "^3.49.0",
+				"@aws-sdk/node-http-handler": "^3.49.0",
+				"@aws-sdk/protocol-http": "^3.49.0",
+				"@aws-sdk/signature-v4": "^3.49.0",
+				"cli-progress": "^3.10.0",
+				"commander": "^9.0.0",
+				"cross-env": "^7.0.3",
+				"undici": "^4.13.0",
+				"winston": "^3.5.1"
+			}
+		},
+		"node_modules/@aws-crypto/ie11-detection": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+			"integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.1.tgz",
+			"integrity": "sha512-P4Af7E2iJqZN2HYMdWINEg++OC2CtP1ygTx6WQCzZISQA+i3Q+K3E8S8t/PSYqUnvtfh5XVjbFT9uA+4IT8C2w==",
+			"dependencies": {
+				"@aws-crypto/ie11-detection": "^2.0.0",
+				"@aws-crypto/sha256-js": "^2.0.1",
+				"@aws-crypto/supports-web-crypto": "^2.0.0",
+				"@aws-crypto/util": "^2.0.1",
+				"@aws-sdk/types": "^3.1.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
+			"integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+			"dependencies": {
+				"@aws-crypto/util": "^2.0.1",
+				"@aws-sdk/types": "^3.1.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+			"integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+			"dependencies": {
+				"@aws-crypto/util": "^2.0.0",
+				"@aws-sdk/types": "^3.1.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+			"integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+			"integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.1.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-sdk/abort-controller": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.49.0.tgz",
+			"integrity": "sha512-1qLlgOgg3yrtm+AJEP7yoIk90o6ns3Dia8S9DRjj29jY40446etH3v/tIbHPE+em69HLXl1K6e5KD6t7EDxnlg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.49.0.tgz",
+			"integrity": "sha512-rY8uZo4DeNwwKf+Sx0TX/5ysXJKf+0SQSCTWD9S4a0AjtiaLc6hKCX+sJY43VDHvNYieKtXLDYHBdhhqZKwG+g==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "2.0.0",
+				"@aws-crypto/sha256-js": "2.0.0",
+				"@aws-sdk/config-resolver": "3.49.0",
+				"@aws-sdk/fetch-http-handler": "3.49.0",
+				"@aws-sdk/hash-node": "3.49.0",
+				"@aws-sdk/invalid-dependency": "3.49.0",
+				"@aws-sdk/middleware-content-length": "3.49.0",
+				"@aws-sdk/middleware-host-header": "3.49.0",
+				"@aws-sdk/middleware-logger": "3.49.0",
+				"@aws-sdk/middleware-retry": "3.49.0",
+				"@aws-sdk/middleware-serde": "3.49.0",
+				"@aws-sdk/middleware-stack": "3.49.0",
+				"@aws-sdk/middleware-user-agent": "3.49.0",
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/node-http-handler": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/smithy-client": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/url-parser": "3.49.0",
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"@aws-sdk/util-base64-node": "3.49.0",
+				"@aws-sdk/util-body-length-browser": "3.49.0",
+				"@aws-sdk/util-body-length-node": "3.49.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.49.0",
+				"@aws-sdk/util-defaults-mode-node": "3.49.0",
+				"@aws-sdk/util-user-agent-browser": "3.49.0",
+				"@aws-sdk/util-user-agent-node": "3.49.0",
+				"@aws-sdk/util-utf8-browser": "3.49.0",
+				"@aws-sdk/util-utf8-node": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+			"integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+			"dependencies": {
+				"@aws-crypto/ie11-detection": "^2.0.0",
+				"@aws-crypto/sha256-js": "^2.0.0",
+				"@aws-crypto/supports-web-crypto": "^2.0.0",
+				"@aws-crypto/util": "^2.0.0",
+				"@aws-sdk/types": "^3.1.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-sdk/config-resolver": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.49.0.tgz",
+			"integrity": "sha512-4kYV+89E9MG+/wfPY3dmwqzquQxNd951jdfjQbSg1ii68X/owqmWda4bLulV0Z4iGUz9TXkbaJCWyRyjsFNe4w==",
+			"dependencies": {
+				"@aws-sdk/signature-v4": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-config-provider": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.49.0.tgz",
+			"integrity": "sha512-mx82N0un6URmmiM11X3ObK3ka5R99lEFdhwPc0jqsCPnXRVioUtK5DXkJ8FmgixbDcs5Pdij9A8MINSeBrG0bQ==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-imds": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.49.0.tgz",
+			"integrity": "sha512-d/H5VgmRiIupQdPg9QcX16kdvuiS/YytRYCQOncVstNXHvYZM9EgeIXJLXyPNaD2W8SS7CBf4KKWYJn3V+9AZw==",
+			"dependencies": {
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/url-parser": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.49.0.tgz",
+			"integrity": "sha512-QlWfxDwZVyX36pghgkKGBR+fBmX/mjmvc0kzxUmqGhUYAkDQ0YKR11ybpGBrxBKT4lIOE+9z6Tu4nLjp3OlJIg==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/credential-provider-sso": "3.49.0",
+				"@aws-sdk/credential-provider-web-identity": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.49.0.tgz",
+			"integrity": "sha512-DonoqOZHcqfNuwMG1fGJpHJTqf1QinihRKzlOoUWzmseqBCiuagGouSN7nOQgee5BrzF0X9/nao9lnPc4on2TA==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/credential-provider-ini": "3.49.0",
+				"@aws-sdk/credential-provider-process": "3.49.0",
+				"@aws-sdk/credential-provider-sso": "3.49.0",
+				"@aws-sdk/credential-provider-web-identity": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.49.0.tgz",
+			"integrity": "sha512-Zn7CJHoXln8O+yBKdTBvcwCz6GDh48s7HtIsqjoOrqoL0oZWhgy8gn8S9KQ+HIqpiO8N0lMMteXuPl5fbC2zGg==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.49.0.tgz",
+			"integrity": "sha512-sFTqbQOyGR88K10Y1OgauEPKDmEibxtAkLSFjkJ6Yw/Jyp+lftchoa+TxRrNvDY1zjZX+XauVI6UmD5Pi4E1NQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.49.0.tgz",
+			"integrity": "sha512-mlIHUTn04unB0HEwEO12YIY5848uE9B+gYI+YwlNZ70KXGs3lj2horOgPgbxeIfulCVw0aRTKChUg2ActTosYg==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/fetch-http-handler": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.49.0.tgz",
+			"integrity": "sha512-ougJRsvoIGP0qTgHSGVF1B5Ui95Y/SP5CpY/y6B8vMGrwJ+MmvcCUE3Qd2UJGjO1PfUneno8PHK4u5x7hc2ceA==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/querystring-builder": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@aws-sdk/hash-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.49.0.tgz",
+			"integrity": "sha512-nRNCmSkcJOzWzKU6NihlKW/6H1HxaaBjUe9ETnwWIgwPC7NZ6IWtri48Cf7Itvveu3dln3ZM2WSXN20TlQpuBw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/invalid-dependency": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.49.0.tgz",
+			"integrity": "sha512-MXf/9l/Oiy+KGKDvInv0RT4rtS+iNftYRTlTmUn3RR74Kz8Fvw+O0RcUjzSrNn5SpjCf/UsGrF+KBTm2gFYQCA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@aws-sdk/is-array-buffer": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.49.0.tgz",
+			"integrity": "sha512-tLba+xvlm1+aAnv+bGieVZo8DCENbqfS9kLf/hp+9hrUSiNAsxs9Pqi34JBpMKGn6h9qORp6f8ClRS+gK8yvWg==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-content-length": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.49.0.tgz",
+			"integrity": "sha512-7IaghPT7X92gNoyn9LzZj4V5YpGPDCYQTWhpzZoIlw88vOR4I0zKg7jwYeElRoNfRCI4OYhF26ajKnNHzNMlbA==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.49.0.tgz",
+			"integrity": "sha512-5l1ILqHs2mGqNvJb5mRe7hHbTQOO292jghE/LItpNx2tiu7BBGzP1bslHcyEVYoRBX9Oqyfou7s9Ww2yBWtImQ==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.49.0.tgz",
+			"integrity": "sha512-OicQ0w5sCJXgpeZ+t3XeJA2R/09YfuSe53Ma6aWZm/2/r8vG/SW0yAnwFvwJeCm3DKtBxU1qO2eWhFqvJuWRVA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-retry": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.49.0.tgz",
+			"integrity": "sha512-RSS4R4PNULHA1b1eYR50YPPfOV2jRuXgLNLVVYMEzzC23MabKEXJYPge+pI1Q9rRrbahVj7aQcOTSpT0MsiEeA==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/service-error-classification": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-serde": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.49.0.tgz",
+			"integrity": "sha512-bMAlwR19uFUZ4om+U+/vnPvkcyYw83HdtERF9wrjAqNUnqYsifA0xn4R7Sakg6CW8V0h82dsST6zVfmHd+E2VA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-stack": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.49.0.tgz",
+			"integrity": "sha512-OZxs2P7EH58gkvkTI7ESlUPGam0TkE0ZxOX35KjCOcYMuWvTMshKBzHRLX64nz3DYdaHSIGHgB1v8LKELZjltw==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.49.0.tgz",
+			"integrity": "sha512-uAcKgafZ12L8UnyeQGgSFtwOKUfiBWDLt4P2fEHvZRz/HAIcK4pu1PXPArjwteinhUiCDNFfPw8hAPvstMoG6w==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/node-config-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.49.0.tgz",
+			"integrity": "sha512-OCn5c6M/RJDEO80Q+Iy4ADSYgqd/uyEsvp+7lU4di4bMND9kYT4JO2ky2SWjIuARGq/mhMOhaN2DO9MbcqV20g==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/node-http-handler": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.49.0.tgz",
+			"integrity": "sha512-t7D9hoSigBihC9RRgYrkzgSER0fYzZe7192pJAaP6jk13ZOpccQRfXZoKge/cm42aHJsTy8DdQdGtLg7wLTp0g==",
+			"dependencies": {
+				"@aws-sdk/abort-controller": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/querystring-builder": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/property-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.49.0.tgz",
+			"integrity": "sha512-6D48YpriOUpniezVuRI8J+MG+vgwb5C1SzBdgN4+S6DqbsEZy+kdEubXdoMICEd+Z8h7lH3p5zMr6po0icGCfA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/protocol-http": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.49.0.tgz",
+			"integrity": "sha512-lb9CO7/vm26v4UwveWb4jSapqWWP/p0b9SuHpRExq+yMuvHqwxcoGrxmvS7FsanWbepRF1895dxU/Ar6/4pviA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/querystring-builder": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.49.0.tgz",
+			"integrity": "sha512-+NlgIYihVyUetZcrF1ADY0eg8WW1/ETD5bzTwguTiKduXVHmavSakXK1jJF5vg05mefljToZXjQnOaEs9+K9LA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-uri-escape": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/querystring-parser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.49.0.tgz",
+			"integrity": "sha512-4bSCHI5A8wi+JjsD1gAhMuGRGjDmlw6MoMWUiv4R2J8Ow/9mV8biKRo2ZytUPiSSu4G5JQ7mEkqFsm/VgkstDQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/service-error-classification": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.49.0.tgz",
+			"integrity": "sha512-iVmf7RcrIsM/We5ip8fe14RzEpSLF5eN8oqhCMftEdmMVnOYMd/9x0f1w69fbyBJNIIpyREqM8eAKz5OWQn5/g==",
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/shared-ini-file-loader": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.49.0.tgz",
+			"integrity": "sha512-TcgKU6U/3JZpenRFhGSy5R5QsBWkYoeawTK1rTK6deu3UbxVwtOkietbfwP3kIwKZ4hz6OkNeHcOJtXX/InZKw==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.49.0.tgz",
+			"integrity": "sha512-mQSGclWmv/9/MsgthBuKMHN6nkkhGTLXspkhqJ9xSUhjhoaHQVwMoJc39PowJGbYFn1AtCvHAqJtFXTGsMRwPA==",
+			"dependencies": {
+				"@aws-sdk/is-array-buffer": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-hex-encoding": "3.49.0",
+				"@aws-sdk/util-uri-escape": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/smithy-client": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.49.0.tgz",
+			"integrity": "sha512-ANh9SlEvuru1DcalVoQ7K6wSCYuw4jyeTsIDsJSa13ckrmXAg+ql9vq61ELAXTSNVmuAISuuPjbVaWvOYCtdCQ==",
+			"dependencies": {
+				"@aws-sdk/middleware-stack": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.49.0.tgz",
+			"integrity": "sha512-8bCqEpquTlPN6xkjaJ+s+RoEFIu5r4G8oXOsQ5HYBvBdpx62HnCqzHLFNHycL2b8sE+VysQgNvmdQYR98vdMGQ==",
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/url-parser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.49.0.tgz",
+			"integrity": "sha512-l5td6eu+sIjzNsZYVGr7Mz6vssf2j/8/QrrTYF76J2R6OoceCsKdyJgJPP/tXBdcp4HUZDdVcMqtWRbxGC4izQ==",
+			"dependencies": {
+				"@aws-sdk/querystring-parser": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-base64-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.49.0.tgz",
+			"integrity": "sha512-HFXJbsJC6AfrnO9M8KuFDo4ihvLbCbCFCfpWy0Gs4t8kTcvGqH8fIpfVsQKAtFHMmb8fen2LduOk+NNSA7srYw==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-base64-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.49.0.tgz",
+			"integrity": "sha512-xFAzOLZJOEZipG3KVLjB5z1g5PJSi6cmZOGWg2NC2/H5N0/Z+e5ObnIH8mpfO1d6kWchUuo3qJ6fTOvg/ynw7A==",
+			"dependencies": {
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-body-length-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.49.0.tgz",
+			"integrity": "sha512-4a9Bw33JGKefaZDORlosQRMKxJGEYEiDD5kgNvwIv+KRl5yj2unePia6aFWMqXTWqidOb9WVlqc0Lh73ei5pTg==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-body-length-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.49.0.tgz",
+			"integrity": "sha512-ME5Sc8jo9BzToUjWskQKZM/NqN9PpwRDTOSH6EISDBUiH5bhWfY8MLkZqIN2UZz/XOiV3yOeWAU+fMYNnGdAQQ==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-buffer-from": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.49.0.tgz",
+			"integrity": "sha512-8JbIPYn91f+16QpDk000PdIBlBZu8/SoL1nF2fpAJ+M98jXpKUws3oiCztJ2FPIKRe/3ikKuZM4HxWrDyJa40Q==",
+			"dependencies": {
+				"@aws-sdk/is-array-buffer": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-config-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.49.0.tgz",
+			"integrity": "sha512-oVGT9q9UIGdv9Cra4B51QNciWKYQXTlfh8oD2FgLp91NbGTIkQLvK7Pah4TbBoa5+0u/obBI07UwCVn7wphWBQ==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-credentials": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.49.0.tgz",
+			"integrity": "sha512-RzbKeuylb56m0zPuLGl5/TkN07+c4PKhZu3hikpsvN8n8n7aFHWPUus63QEGgVaUMCZD0QV6HqJfsCVVFF7UIg==",
+			"dependencies": {
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-defaults-mode-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.49.0.tgz",
+			"integrity": "sha512-MNOvFET5TNBHgvsmfcLuxVDDUV0OIjE1lxrdbXWol7bMgLc2uL3/QOXWKCOUzcFCqTOnWCvbnwkOjs3f7Dpzmw==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-defaults-mode-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.49.0.tgz",
+			"integrity": "sha512-bd5/ZJlNIX25n83mvcCh9eYQiDdf6gLHNH6ZftA/EbFfkE0o/qHrFhBhiB9HBY9ZoHhtoqrJNv5W9qKFHx1EIA==",
+			"dependencies": {
+				"@aws-sdk/config-resolver": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-hex-encoding": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.49.0.tgz",
+			"integrity": "sha512-ZbPu8Dd3Qm0BMP71FWUH7KPpZA/6izfkDlxbvHxtHdW7XYZALuJ0cVRpWGIY2fCSuA9X8Jfn60KMyjuSAuzM1w==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.49.0.tgz",
+			"integrity": "sha512-ryw+t+quF1raaK0nXSplMiCVnahNLNgNDijZCFFkddGTMaCy+L4VRLYyNms3bgwt3G0BmVn9f3uyDWRSkn5sSg==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-uri-escape": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.49.0.tgz",
+			"integrity": "sha512-NH7iQUYvijYZEOzZkF/QQrp8kBOA9H0Z89hR/63FDCjr1M0Cdcs1bLaFO0a0qbW9NQtoYNsMBMk7pTveDrAzTw==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.49.0.tgz",
+			"integrity": "sha512-RR4E6WlDSu9SivPjx/Jddo87PeVg6dhRL0XGdDBpew7i8bfwqCvxQydkbWIetxucLrt9zII9QnLDQUPBue1xUw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.49.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.49.0.tgz",
+			"integrity": "sha512-ixUkF6kcDfsWO0kivyOKAnBITJm7InGa04ALbgAfuuE7RU1cVkXVMFIn5vux7QkziK7+JwozM9SNPIwNukElDw==",
+			"dependencies": {
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-utf8-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.49.0.tgz",
+			"integrity": "sha512-u9ZgAiTWX9yZFQ/ptlnVpYJ/rXF7aE2Wagar1IjhZrnxXbpVJvcX1EeRayxI1P5AAp2y2fiEKHZzX9ugTwOcEg==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-utf8-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.49.0.tgz",
+			"integrity": "sha512-QTF5b5OT2y6xsQl8sDiiXqg2n/VtgqFA+tP3WMooOSFd/ZFBbT6HoiSHXHMeTjpB/L9ZT+eUaCoBz8Jq09lBDg==",
+			"dependencies": {
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@dabh/diagnostics": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+			"integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+			"dependencies": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/async": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+		},
+		"node_modules/bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+		},
+		"node_modules/cli-progress": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
+			"integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
+			"dependencies": {
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/color": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+			"dependencies": {
+				"color-convert": "^1.9.3",
+				"color-string": "^1.6.0"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"node_modules/color-string": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+			"dependencies": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
+		},
+		"node_modules/colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/colorspace": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+			"dependencies": {
+				"color": "^3.1.3",
+				"text-hex": "1.0.x"
+			}
+		},
+		"node_modules/commander": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+			"integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+			"engines": {
+				"node": "^12.20.0 || >=14"
+			}
+		},
+		"node_modules/cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"bin": {
+				"cross-env": "src/bin/cross-env.js",
+				"cross-env-shell": "src/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=10.14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"node_modules/enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+		},
+		"node_modules/fecha": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
+		},
+		"node_modules/fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"node_modules/kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+		},
+		"node_modules/logform": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
+			"integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
+			"dependencies": {
+				"colors": "1.4.0",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^1.1.0",
+				"triple-beam": "^1.3.0"
+			}
+		},
+		"node_modules/logform/node_modules/safe-stable-stringify": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+			"integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"node_modules/one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"dependencies": {
+				"fn.name": "1.x.x"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"dependencies": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
+		"node_modules/stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+		},
+		"node_modules/triple-beam": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+		},
+		"node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+		},
+		"node_modules/undici": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
+			"integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA==",
+			"engines": {
+				"node": ">=12.18"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/winston": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
+			"integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
+			"dependencies": {
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.3.2",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.4.2"
+			},
+			"engines": {
+				"node": ">= 6.4.0"
+			}
+		},
+		"node_modules/winston-transport": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+			"dependencies": {
+				"logform": "^2.3.2",
+				"readable-stream": "^3.6.0",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 6.4.0"
+			}
+		}
+	},
+	"dependencies": {
+		"@aws-crypto/ie11-detection": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+			"integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+			"requires": {
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/sha256-browser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.1.tgz",
+			"integrity": "sha512-P4Af7E2iJqZN2HYMdWINEg++OC2CtP1ygTx6WQCzZISQA+i3Q+K3E8S8t/PSYqUnvtfh5XVjbFT9uA+4IT8C2w==",
+			"requires": {
+				"@aws-crypto/ie11-detection": "^2.0.0",
+				"@aws-crypto/sha256-js": "^2.0.1",
+				"@aws-crypto/supports-web-crypto": "^2.0.0",
+				"@aws-crypto/util": "^2.0.1",
+				"@aws-sdk/types": "^3.1.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"@aws-crypto/sha256-js": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
+					"integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+					"requires": {
+						"@aws-crypto/util": "^2.0.1",
+						"@aws-sdk/types": "^3.1.0",
+						"tslib": "^1.11.1"
+					}
+				},
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/sha256-js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+			"integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+			"requires": {
+				"@aws-crypto/util": "^2.0.0",
+				"@aws-sdk/types": "^3.1.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/supports-web-crypto": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+			"integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+			"requires": {
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/util": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+			"integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+			"requires": {
+				"@aws-sdk/types": "^3.1.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-sdk/abort-controller": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.49.0.tgz",
+			"integrity": "sha512-1qLlgOgg3yrtm+AJEP7yoIk90o6ns3Dia8S9DRjj29jY40446etH3v/tIbHPE+em69HLXl1K6e5KD6t7EDxnlg==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/client-sso": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.49.0.tgz",
+			"integrity": "sha512-rY8uZo4DeNwwKf+Sx0TX/5ysXJKf+0SQSCTWD9S4a0AjtiaLc6hKCX+sJY43VDHvNYieKtXLDYHBdhhqZKwG+g==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "2.0.0",
+				"@aws-crypto/sha256-js": "2.0.0",
+				"@aws-sdk/config-resolver": "3.49.0",
+				"@aws-sdk/fetch-http-handler": "3.49.0",
+				"@aws-sdk/hash-node": "3.49.0",
+				"@aws-sdk/invalid-dependency": "3.49.0",
+				"@aws-sdk/middleware-content-length": "3.49.0",
+				"@aws-sdk/middleware-host-header": "3.49.0",
+				"@aws-sdk/middleware-logger": "3.49.0",
+				"@aws-sdk/middleware-retry": "3.49.0",
+				"@aws-sdk/middleware-serde": "3.49.0",
+				"@aws-sdk/middleware-stack": "3.49.0",
+				"@aws-sdk/middleware-user-agent": "3.49.0",
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/node-http-handler": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/smithy-client": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/url-parser": "3.49.0",
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"@aws-sdk/util-base64-node": "3.49.0",
+				"@aws-sdk/util-body-length-browser": "3.49.0",
+				"@aws-sdk/util-body-length-node": "3.49.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.49.0",
+				"@aws-sdk/util-defaults-mode-node": "3.49.0",
+				"@aws-sdk/util-user-agent-browser": "3.49.0",
+				"@aws-sdk/util-user-agent-node": "3.49.0",
+				"@aws-sdk/util-utf8-browser": "3.49.0",
+				"@aws-sdk/util-utf8-node": "3.49.0",
+				"tslib": "^2.3.0"
+			},
+			"dependencies": {
+				"@aws-crypto/sha256-browser": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+					"integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+					"requires": {
+						"@aws-crypto/ie11-detection": "^2.0.0",
+						"@aws-crypto/sha256-js": "^2.0.0",
+						"@aws-crypto/supports-web-crypto": "^2.0.0",
+						"@aws-crypto/util": "^2.0.0",
+						"@aws-sdk/types": "^3.1.0",
+						"@aws-sdk/util-locate-window": "^3.0.0",
+						"@aws-sdk/util-utf8-browser": "^3.0.0",
+						"tslib": "^1.11.1"
+					},
+					"dependencies": {
+						"tslib": {
+							"version": "1.14.1",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+							"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+						}
+					}
+				}
+			}
+		},
+		"@aws-sdk/config-resolver": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.49.0.tgz",
+			"integrity": "sha512-4kYV+89E9MG+/wfPY3dmwqzquQxNd951jdfjQbSg1ii68X/owqmWda4bLulV0Z4iGUz9TXkbaJCWyRyjsFNe4w==",
+			"requires": {
+				"@aws-sdk/signature-v4": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-config-provider": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-env": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.49.0.tgz",
+			"integrity": "sha512-mx82N0un6URmmiM11X3ObK3ka5R99lEFdhwPc0jqsCPnXRVioUtK5DXkJ8FmgixbDcs5Pdij9A8MINSeBrG0bQ==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-imds": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.49.0.tgz",
+			"integrity": "sha512-d/H5VgmRiIupQdPg9QcX16kdvuiS/YytRYCQOncVstNXHvYZM9EgeIXJLXyPNaD2W8SS7CBf4KKWYJn3V+9AZw==",
+			"requires": {
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/url-parser": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-ini": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.49.0.tgz",
+			"integrity": "sha512-QlWfxDwZVyX36pghgkKGBR+fBmX/mjmvc0kzxUmqGhUYAkDQ0YKR11ybpGBrxBKT4lIOE+9z6Tu4nLjp3OlJIg==",
+			"requires": {
+				"@aws-sdk/credential-provider-env": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/credential-provider-sso": "3.49.0",
+				"@aws-sdk/credential-provider-web-identity": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.49.0.tgz",
+			"integrity": "sha512-DonoqOZHcqfNuwMG1fGJpHJTqf1QinihRKzlOoUWzmseqBCiuagGouSN7nOQgee5BrzF0X9/nao9lnPc4on2TA==",
+			"requires": {
+				"@aws-sdk/credential-provider-env": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/credential-provider-ini": "3.49.0",
+				"@aws-sdk/credential-provider-process": "3.49.0",
+				"@aws-sdk/credential-provider-sso": "3.49.0",
+				"@aws-sdk/credential-provider-web-identity": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-process": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.49.0.tgz",
+			"integrity": "sha512-Zn7CJHoXln8O+yBKdTBvcwCz6GDh48s7HtIsqjoOrqoL0oZWhgy8gn8S9KQ+HIqpiO8N0lMMteXuPl5fbC2zGg==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-sso": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.49.0.tgz",
+			"integrity": "sha512-sFTqbQOyGR88K10Y1OgauEPKDmEibxtAkLSFjkJ6Yw/Jyp+lftchoa+TxRrNvDY1zjZX+XauVI6UmD5Pi4E1NQ==",
+			"requires": {
+				"@aws-sdk/client-sso": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-web-identity": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.49.0.tgz",
+			"integrity": "sha512-mlIHUTn04unB0HEwEO12YIY5848uE9B+gYI+YwlNZ70KXGs3lj2horOgPgbxeIfulCVw0aRTKChUg2ActTosYg==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/fetch-http-handler": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.49.0.tgz",
+			"integrity": "sha512-ougJRsvoIGP0qTgHSGVF1B5Ui95Y/SP5CpY/y6B8vMGrwJ+MmvcCUE3Qd2UJGjO1PfUneno8PHK4u5x7hc2ceA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/querystring-builder": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/hash-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.49.0.tgz",
+			"integrity": "sha512-nRNCmSkcJOzWzKU6NihlKW/6H1HxaaBjUe9ETnwWIgwPC7NZ6IWtri48Cf7Itvveu3dln3ZM2WSXN20TlQpuBw==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/invalid-dependency": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.49.0.tgz",
+			"integrity": "sha512-MXf/9l/Oiy+KGKDvInv0RT4rtS+iNftYRTlTmUn3RR74Kz8Fvw+O0RcUjzSrNn5SpjCf/UsGrF+KBTm2gFYQCA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/is-array-buffer": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.49.0.tgz",
+			"integrity": "sha512-tLba+xvlm1+aAnv+bGieVZo8DCENbqfS9kLf/hp+9hrUSiNAsxs9Pqi34JBpMKGn6h9qORp6f8ClRS+gK8yvWg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-content-length": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.49.0.tgz",
+			"integrity": "sha512-7IaghPT7X92gNoyn9LzZj4V5YpGPDCYQTWhpzZoIlw88vOR4I0zKg7jwYeElRoNfRCI4OYhF26ajKnNHzNMlbA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-host-header": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.49.0.tgz",
+			"integrity": "sha512-5l1ILqHs2mGqNvJb5mRe7hHbTQOO292jghE/LItpNx2tiu7BBGzP1bslHcyEVYoRBX9Oqyfou7s9Ww2yBWtImQ==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-logger": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.49.0.tgz",
+			"integrity": "sha512-OicQ0w5sCJXgpeZ+t3XeJA2R/09YfuSe53Ma6aWZm/2/r8vG/SW0yAnwFvwJeCm3DKtBxU1qO2eWhFqvJuWRVA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-retry": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.49.0.tgz",
+			"integrity": "sha512-RSS4R4PNULHA1b1eYR50YPPfOV2jRuXgLNLVVYMEzzC23MabKEXJYPge+pI1Q9rRrbahVj7aQcOTSpT0MsiEeA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/service-error-classification": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0",
+				"uuid": "^8.3.2"
+			}
+		},
+		"@aws-sdk/middleware-serde": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.49.0.tgz",
+			"integrity": "sha512-bMAlwR19uFUZ4om+U+/vnPvkcyYw83HdtERF9wrjAqNUnqYsifA0xn4R7Sakg6CW8V0h82dsST6zVfmHd+E2VA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-stack": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.49.0.tgz",
+			"integrity": "sha512-OZxs2P7EH58gkvkTI7ESlUPGam0TkE0ZxOX35KjCOcYMuWvTMshKBzHRLX64nz3DYdaHSIGHgB1v8LKELZjltw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-user-agent": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.49.0.tgz",
+			"integrity": "sha512-uAcKgafZ12L8UnyeQGgSFtwOKUfiBWDLt4P2fEHvZRz/HAIcK4pu1PXPArjwteinhUiCDNFfPw8hAPvstMoG6w==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/node-config-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.49.0.tgz",
+			"integrity": "sha512-OCn5c6M/RJDEO80Q+Iy4ADSYgqd/uyEsvp+7lU4di4bMND9kYT4JO2ky2SWjIuARGq/mhMOhaN2DO9MbcqV20g==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/node-http-handler": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.49.0.tgz",
+			"integrity": "sha512-t7D9hoSigBihC9RRgYrkzgSER0fYzZe7192pJAaP6jk13ZOpccQRfXZoKge/cm42aHJsTy8DdQdGtLg7wLTp0g==",
+			"requires": {
+				"@aws-sdk/abort-controller": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/querystring-builder": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/property-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.49.0.tgz",
+			"integrity": "sha512-6D48YpriOUpniezVuRI8J+MG+vgwb5C1SzBdgN4+S6DqbsEZy+kdEubXdoMICEd+Z8h7lH3p5zMr6po0icGCfA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/protocol-http": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.49.0.tgz",
+			"integrity": "sha512-lb9CO7/vm26v4UwveWb4jSapqWWP/p0b9SuHpRExq+yMuvHqwxcoGrxmvS7FsanWbepRF1895dxU/Ar6/4pviA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/querystring-builder": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.49.0.tgz",
+			"integrity": "sha512-+NlgIYihVyUetZcrF1ADY0eg8WW1/ETD5bzTwguTiKduXVHmavSakXK1jJF5vg05mefljToZXjQnOaEs9+K9LA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-uri-escape": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/querystring-parser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.49.0.tgz",
+			"integrity": "sha512-4bSCHI5A8wi+JjsD1gAhMuGRGjDmlw6MoMWUiv4R2J8Ow/9mV8biKRo2ZytUPiSSu4G5JQ7mEkqFsm/VgkstDQ==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/service-error-classification": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.49.0.tgz",
+			"integrity": "sha512-iVmf7RcrIsM/We5ip8fe14RzEpSLF5eN8oqhCMftEdmMVnOYMd/9x0f1w69fbyBJNIIpyREqM8eAKz5OWQn5/g=="
+		},
+		"@aws-sdk/shared-ini-file-loader": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.49.0.tgz",
+			"integrity": "sha512-TcgKU6U/3JZpenRFhGSy5R5QsBWkYoeawTK1rTK6deu3UbxVwtOkietbfwP3kIwKZ4hz6OkNeHcOJtXX/InZKw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/signature-v4": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.49.0.tgz",
+			"integrity": "sha512-mQSGclWmv/9/MsgthBuKMHN6nkkhGTLXspkhqJ9xSUhjhoaHQVwMoJc39PowJGbYFn1AtCvHAqJtFXTGsMRwPA==",
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-hex-encoding": "3.49.0",
+				"@aws-sdk/util-uri-escape": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/smithy-client": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.49.0.tgz",
+			"integrity": "sha512-ANh9SlEvuru1DcalVoQ7K6wSCYuw4jyeTsIDsJSa13ckrmXAg+ql9vq61ELAXTSNVmuAISuuPjbVaWvOYCtdCQ==",
+			"requires": {
+				"@aws-sdk/middleware-stack": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/types": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.49.0.tgz",
+			"integrity": "sha512-8bCqEpquTlPN6xkjaJ+s+RoEFIu5r4G8oXOsQ5HYBvBdpx62HnCqzHLFNHycL2b8sE+VysQgNvmdQYR98vdMGQ=="
+		},
+		"@aws-sdk/url-parser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.49.0.tgz",
+			"integrity": "sha512-l5td6eu+sIjzNsZYVGr7Mz6vssf2j/8/QrrTYF76J2R6OoceCsKdyJgJPP/tXBdcp4HUZDdVcMqtWRbxGC4izQ==",
+			"requires": {
+				"@aws-sdk/querystring-parser": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-base64-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.49.0.tgz",
+			"integrity": "sha512-HFXJbsJC6AfrnO9M8KuFDo4ihvLbCbCFCfpWy0Gs4t8kTcvGqH8fIpfVsQKAtFHMmb8fen2LduOk+NNSA7srYw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-base64-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.49.0.tgz",
+			"integrity": "sha512-xFAzOLZJOEZipG3KVLjB5z1g5PJSi6cmZOGWg2NC2/H5N0/Z+e5ObnIH8mpfO1d6kWchUuo3qJ6fTOvg/ynw7A==",
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-body-length-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.49.0.tgz",
+			"integrity": "sha512-4a9Bw33JGKefaZDORlosQRMKxJGEYEiDD5kgNvwIv+KRl5yj2unePia6aFWMqXTWqidOb9WVlqc0Lh73ei5pTg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-body-length-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.49.0.tgz",
+			"integrity": "sha512-ME5Sc8jo9BzToUjWskQKZM/NqN9PpwRDTOSH6EISDBUiH5bhWfY8MLkZqIN2UZz/XOiV3yOeWAU+fMYNnGdAQQ==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-buffer-from": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.49.0.tgz",
+			"integrity": "sha512-8JbIPYn91f+16QpDk000PdIBlBZu8/SoL1nF2fpAJ+M98jXpKUws3oiCztJ2FPIKRe/3ikKuZM4HxWrDyJa40Q==",
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-config-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.49.0.tgz",
+			"integrity": "sha512-oVGT9q9UIGdv9Cra4B51QNciWKYQXTlfh8oD2FgLp91NbGTIkQLvK7Pah4TbBoa5+0u/obBI07UwCVn7wphWBQ==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-credentials": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.49.0.tgz",
+			"integrity": "sha512-RzbKeuylb56m0zPuLGl5/TkN07+c4PKhZu3hikpsvN8n8n7aFHWPUus63QEGgVaUMCZD0QV6HqJfsCVVFF7UIg==",
+			"requires": {
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-defaults-mode-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.49.0.tgz",
+			"integrity": "sha512-MNOvFET5TNBHgvsmfcLuxVDDUV0OIjE1lxrdbXWol7bMgLc2uL3/QOXWKCOUzcFCqTOnWCvbnwkOjs3f7Dpzmw==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-defaults-mode-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.49.0.tgz",
+			"integrity": "sha512-bd5/ZJlNIX25n83mvcCh9eYQiDdf6gLHNH6ZftA/EbFfkE0o/qHrFhBhiB9HBY9ZoHhtoqrJNv5W9qKFHx1EIA==",
+			"requires": {
+				"@aws-sdk/config-resolver": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-hex-encoding": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.49.0.tgz",
+			"integrity": "sha512-ZbPu8Dd3Qm0BMP71FWUH7KPpZA/6izfkDlxbvHxtHdW7XYZALuJ0cVRpWGIY2fCSuA9X8Jfn60KMyjuSAuzM1w==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-locate-window": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.49.0.tgz",
+			"integrity": "sha512-ryw+t+quF1raaK0nXSplMiCVnahNLNgNDijZCFFkddGTMaCy+L4VRLYyNms3bgwt3G0BmVn9f3uyDWRSkn5sSg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-uri-escape": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.49.0.tgz",
+			"integrity": "sha512-NH7iQUYvijYZEOzZkF/QQrp8kBOA9H0Z89hR/63FDCjr1M0Cdcs1bLaFO0a0qbW9NQtoYNsMBMk7pTveDrAzTw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-user-agent-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.49.0.tgz",
+			"integrity": "sha512-RR4E6WlDSu9SivPjx/Jddo87PeVg6dhRL0XGdDBpew7i8bfwqCvxQydkbWIetxucLrt9zII9QnLDQUPBue1xUw==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-user-agent-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.49.0.tgz",
+			"integrity": "sha512-ixUkF6kcDfsWO0kivyOKAnBITJm7InGa04ALbgAfuuE7RU1cVkXVMFIn5vux7QkziK7+JwozM9SNPIwNukElDw==",
+			"requires": {
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-utf8-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.49.0.tgz",
+			"integrity": "sha512-u9ZgAiTWX9yZFQ/ptlnVpYJ/rXF7aE2Wagar1IjhZrnxXbpVJvcX1EeRayxI1P5AAp2y2fiEKHZzX9ugTwOcEg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-utf8-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.49.0.tgz",
+			"integrity": "sha512-QTF5b5OT2y6xsQl8sDiiXqg2n/VtgqFA+tP3WMooOSFd/ZFBbT6HoiSHXHMeTjpB/L9ZT+eUaCoBz8Jq09lBDg==",
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@dabh/diagnostics": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+			"integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+			"requires": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
+			}
+		},
+		"ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+		},
+		"async": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+		},
+		"bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+		},
+		"cli-progress": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
+			"integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
+			"requires": {
+				"string-width": "^4.2.0"
+			}
+		},
+		"color": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+			"requires": {
+				"color-convert": "^1.9.3",
+				"color-string": "^1.6.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-string": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+			"requires": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
+		},
+		"colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+		},
+		"colorspace": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+			"requires": {
+				"color": "^3.1.3",
+				"text-hex": "1.0.x"
+			}
+		},
+		"commander": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+			"integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
+		},
+		"cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"requires": {
+				"cross-spawn": "^7.0.1"
+			}
+		},
+		"cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+		},
+		"fecha": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
+		},
+		"fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+		},
+		"is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+		},
+		"logform": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
+			"integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
+			"requires": {
+				"colors": "1.4.0",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^1.1.0",
+				"triple-beam": "^1.3.0"
+			},
+			"dependencies": {
+				"safe-stable-stringify": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+					"integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
+				}
+			}
+		},
+		"ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"requires": {
+				"fn.name": "1.x.x"
+			}
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+		},
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
+		"safe-stable-stringify": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"requires": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"requires": {
+				"ansi-regex": "^5.0.1"
+			}
+		},
+		"text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+		},
+		"triple-beam": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+		},
+		"tslib": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+		},
+		"undici": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
+			"integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA=="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"winston": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
+			"integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
+			"requires": {
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.3.2",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.4.2"
+			}
+		},
+		"winston-transport": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+			"requires": {
+				"logform": "^2.3.2",
+				"readable-stream": "^3.6.0",
+				"triple-beam": "^1.3.0"
+			}
+		}
+	}
 }

--- a/arxlive_spotlight_annotation/package.json
+++ b/arxlive_spotlight_annotation/package.json
@@ -1,28 +1,32 @@
 {
-  "name": "dap_dv_backends",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nestauk/dap_dv_backends.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/nestauk/dap_dv_backends/issues"
-  },
-  "homepage": "https://github.com/nestauk/dap_dv_backends#readme",
-  "dependencies": {
-    "@aws-crypto/sha256-browser": "^2.0.1",
-    "@aws-sdk/credential-provider-node": "^3.49.0",
-    "@aws-sdk/node-http-handler": "^3.49.0",
-    "@aws-sdk/protocol-http": "^3.49.0",
-    "@aws-sdk/signature-v4": "^3.49.0",
-    "commander": "^9.0.0"
-  }
+	"author": "",
+	"bugs": {
+		"url": "https://github.com/nestauk/dap_dv_backends/issues"
+	},
+	"dependencies": {
+		"@aws-crypto/sha256-browser": "^2.0.1",
+		"@aws-sdk/credential-provider-node": "^3.49.0",
+		"@aws-sdk/node-http-handler": "^3.49.0",
+		"@aws-sdk/protocol-http": "^3.49.0",
+		"@aws-sdk/signature-v4": "^3.49.0",
+		"cli-progress": "^3.10.0",
+		"commander": "^9.0.0",
+		"cross-env": "^7.0.3",
+		"undici": "^4.13.0",
+		"winston": "^3.5.1"
+	},
+	"description": "",
+	"homepage": "https://github.com/nestauk/dap_dv_backends#readme",
+	"keywords": [],
+	"license": "ISC",
+	"main": "index.js",
+	"name": "arxlive_spotlight_annotation",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/nestauk/dap_dv_backends.git"
+	},
+	"scripts": {
+		"annotate": "cross-env NODE_ENV=production node src/bin/es/annotate.mjs --index arxiv_v6 --spotlight http://localhost:2222/rest/annotate --size 100"
+	},
+	"version": "0.0.1"
 }

--- a/arxlive_spotlight_annotation/src/bin/es/annotate.mjs
+++ b/arxlive_spotlight_annotation/src/bin/es/annotate.mjs
@@ -1,0 +1,78 @@
+import { annotate, parseAnnotationResults } from 'dbpedia/spotlight.mjs';
+import { scroll, clearScroll } from 'es/search.mjs';
+import { count } from 'es/index.mjs';
+import { update } from 'es/update.mjs';
+import * as cliProgress from 'cli-progress';
+import { Command } from 'commander';
+
+import { logger } from '../../node_modules/logging.mjs';
+import { arxliveCopy } from 'conf/config.mjs';
+
+const confidenceValues = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
+
+const program = new Command();
+program.option(
+	'-d, --domain <domain>',
+	'ES domain on which to annotate',
+	arxliveCopy
+);
+program.option('-i, --index <index>', 'Index on which to annotate', 'test');
+program.option(
+	'-s, --spotlight <endpoint>',
+	'Endpoint for spotlight annotator',
+	undefined
+);
+program.option('-p, --size <size>', 'Size of page to scroll with', 100);
+program.option(
+	'-z, --pages <number_of_pages>',
+	'Number of pages to iterate over',
+	'all'
+);
+program.parse();
+const options = program.opts();
+
+// progress bar
+const bar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+let currentDocumentCount = 0;
+
+const processHit = async hit => {
+	currentDocumentCount++;
+	bar.update(currentDocumentCount);
+	try {
+		if ('dbpedia_entities' in hit._source) {
+			logger.verbose('skipping', hit);
+			return Promise.resolve();
+		}
+		const spotlightResults = await Promise.all(
+			confidenceValues.map(confidence =>
+				annotate(hit._source.textBody_abstract_article, confidence, {
+					endpoint: options.spotlight,
+				})
+			)
+		);
+		const spotlightTerms = spotlightResults.map(parseAnnotationResults);
+		return update(options.domain, options.index, hit._id, {
+			dbpedia_entities: spotlightTerms,
+		});
+	} catch (error) {
+		logger.error(`Could not annotate ${hit._id}`, error);
+	}
+};
+
+const main = async () => {
+	const totalDocuments = await count(options.domain, options.index);
+	bar.start(totalDocuments, 0);
+
+	const scroller = scroll(options.domain, options.index, {
+		size: options.size,
+		pages: options.pages,
+	});
+
+	for await (let page of scroller) {
+		await Promise.all(page.hits.hits.map(processHit));
+	}
+	bar.stop();
+	clearScroll(options.domain);
+};
+
+main(options);

--- a/arxlive_spotlight_annotation/src/bin/es/query.mjs
+++ b/arxlive_spotlight_annotation/src/bin/es/query.mjs
@@ -1,0 +1,27 @@
+import { Command } from 'commander';
+
+import { buildRequest, makeRequest } from 'es/requests.mjs';
+import { arxliveCopy } from 'conf/config.mjs';
+
+const program = new Command();
+
+program
+	.command('query')
+	.description('Queries the endpoint')
+	.argument('<query>', 'query term')
+	.argument('[domain]', 'domain on which to register snapshot')
+	.action(async (query, domain = arxliveCopy) => {
+		const path = `_search`;
+		const payload = { size: 2 };
+		const request = buildRequest(
+			domain,
+			path,
+			'POST',
+			JSON.stringify(payload),
+			{ q: query }
+		);
+		console.log(request);
+		await makeRequest(request, { verbose: true });
+	});
+
+program.parse();

--- a/arxlive_spotlight_annotation/src/node_modules/conf/config.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/conf/config.mjs
@@ -1,0 +1,4 @@
+export const arxliveCopy =
+	'search-datavis-arxlive-copy-n6ltva3lqh7x7xb6ucpaqfb5a4.eu-west-2.es.amazonaws.com';
+export const ec2 = 'http://ec2-18-170-45-162.eu-west-2.compute.amazonaws.com';
+export const spotlightEndpoint = `${ec2}:2222/rest/annotate`;

--- a/arxlive_spotlight_annotation/src/node_modules/dbpedia/spotlight.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/dbpedia/spotlight.mjs
@@ -1,0 +1,46 @@
+import fetch from 'undici';
+
+import { logger } from '../logging.mjs';
+import { spotlightEndpoint } from 'conf/config.mjs'
+
+export const annotate = async (
+	text,
+	confidence,
+	{ endpoint = spotlightEndpoint } = {}
+) => {
+	const url = new URL(endpoint);
+	const body = `text=${text}&confidence=${confidence}`;
+	const response = await fetch(url, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'content-type': 'application/x-www-form-urlencoded',
+		},
+		body: encodeURI(body),
+	});
+	if (response.ok) {
+		return response.json();
+	} else {
+		logger.warn(response);
+		logger.error(new Error('Something went wrong with the annotation...'));
+	}
+};
+
+export const parseAnnotationResults = (results) => {
+	const resultSubset = results.Resources
+		? results.Resources.map((result) => {
+				return {
+					'@URI': result['@URI'],
+					'@surfaceForm': result['@surfaceForm'],
+					'@similarityScore': result['@similarityScore'],
+					'@percentageOfSecondRank':
+						result['@percentageOfSecondRank'],
+				};
+		  })
+		: [];
+
+	return {
+		confidence: results['@confidence'],
+		results: resultSubset,
+	};
+};

--- a/arxlive_spotlight_annotation/src/node_modules/es/index.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/index.mjs
@@ -1,0 +1,16 @@
+import { buildRequest, makeRequest } from 'es/requests.mjs';
+
+export const count = async (
+	domain,
+	index,
+	{ returnFullObject = false } = {}
+) => {
+	const path = `${index}/_count`;
+	const request = buildRequest(domain, path, 'GET');
+	const response = await makeRequest(request);
+	if (returnFullObject) {
+		return response;
+	} else {
+		return response.count;
+	}
+};

--- a/arxlive_spotlight_annotation/src/node_modules/es/requests.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/requests.mjs
@@ -5,51 +5,68 @@ import sha256 from '@aws-crypto/sha256-browser';
 import { HttpRequest } from '@aws-sdk/protocol-http';
 const { Sha256 } = sha256;
 
+import { logger } from '../logging.mjs';
+
 const signer = new SignatureV4({
-    credentials: defaultProvider(),
-    region: 'eu-west-2',
-    service: 'es',
-    sha256: Sha256,
+	credentials: defaultProvider(),
+	region: 'eu-west-2',
+	service: 'es',
+	sha256: Sha256,
 });
 
-export const buildRequest = (domain, path, method, body=undefined) => 
-    new HttpRequest({
-        body,
-        headers: {
-            'Content-Type': 'application/json',
-            'host': domain
-       },
-       hostname: domain,
-       method,
-       path
-    })
+export const buildRequest = (
+	domain,
+	path,
+	method,
+	{ payload = undefined, query = {} } = {}
+) => {
+	const body =
+		payload && typeof payload !== 'string'
+			? JSON.stringify(payload)
+			: payload;
+	return new HttpRequest({
+		body,
+		method,
+		path,
+		query,
+		headers: {
+			'Content-Type': 'application/json',
+			host: domain,
+		},
+		hostname: domain,
+	});
+};
 
-export const makeRequest = async (request, { verbose=false }) => {
-
+export const makeRequest = async (request, { verbose = false } = {}) => {
 	// Sign the request
 	const signedRequest = await signer.sign(request);
 	// Send the request
 	const client = new NodeHttpHandler();
 	const { response } = await client.handle(signedRequest);
 
-    if (verbose) {
-	    console.log(response.statusCode + ' ' + response.body.statusMessage);
-    }
+	if (verbose) {
+		logger.info(response.statusCode + ' ' + response.body.statusMessage);
+	}
 
 	var responseBody = '';
-	await new Promise(() => {
-		response.body.on('data', chunk => {
+	await new Promise((resolve) => {
+		response.body.on('data', (chunk) => {
 			responseBody += chunk;
 		});
 		response.body.on('end', () => {
 			responseBody = JSON.parse(responseBody);
-            if (verbose) {
-			console.log('Response body:');
-			console.log(JSON.stringify(responseBody, null, 2));
-            }
-            return responseBody;
+			if (verbose) {
+				logger.info(
+					'Response body: ',
+					JSON.stringify(responseBody, null, 2)
+				);
+			}
+			resolve(responseBody);
 		});
-	}).catch(error => {
-		console.log('Error: ' + error);
-	});
-}
+	})
+		.then((value) => value)
+		.catch((error) => {
+			logger.error(error);
+		});
+	return responseBody;
+};

--- a/arxlive_spotlight_annotation/src/node_modules/es/search.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/search.mjs
@@ -1,0 +1,46 @@
+import { buildRequest, makeRequest } from 'es/requests.mjs';
+
+export const clearScroll = async (domain, id = null) => {
+	const payload = id ? { scroll_id: id } : undefined;
+	const path = id ? '_search/scroll' : '_search/scroll/_all';
+	const request = buildRequest(domain, path, 'DELETE', { payload });
+	const result = makeRequest(request);
+	return result;
+};
+
+const first = async (domain, index, size) => {
+	const path = `${index}/_search`;
+	const query = { scroll: '1m' };
+	const payload = { size, sort: ['_doc'] };
+	const firstRequest = buildRequest(domain, path, 'POST', {
+		payload,
+		query,
+	});
+	const result = await makeRequest(firstRequest);
+	return result;
+};
+// subsequent requests should be made using the _scroll_id
+const subsequent = async (domain, id) => {
+	const path = `_search/scroll`;
+	const payload = { scroll: '1m', scroll_id: id };
+	const subsequentRequest = buildRequest(domain, path, 'POST', {
+		payload,
+	});
+	const result = await makeRequest(subsequentRequest);
+	return result;
+};
+
+export async function* scroll(
+	domain,
+	index,
+	{ size = 1000, pages = 'all' } = {}
+) {
+	// set limit to infinity if all to iterate all results
+	const limit = pages === 'all' ? Infinity : pages;
+	let next = await first(domain, index, size);
+	for (let i = 0; i < limit && next.hits.hits.length !== 0; i++) {
+		yield next;
+		next = await subsequent(domain, next._scroll_id);
+	}
+	return;
+}

--- a/arxlive_spotlight_annotation/src/node_modules/es/update.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/update.mjs
@@ -1,0 +1,9 @@
+import { buildRequest, makeRequest } from 'es/requests.mjs';
+
+export const update = async (domain, index, id, doc) => {
+	const path = `${index}/_update/${id}`;
+	const payload = { doc };
+	const request = buildRequest(domain, path, 'POST', { payload });
+	const response = makeRequest(request);
+	return response;
+};

--- a/arxlive_spotlight_annotation/src/node_modules/logging.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/logging.mjs
@@ -1,0 +1,40 @@
+import { createLogger, format, transports } from 'winston';
+import * as fs from 'fs/promises';
+
+await fs.mkdir('logs', { recursive: true });
+
+export const logger = createLogger({
+	level: 'info',
+	format: format.combine(
+		format.timestamp({
+			format: 'YYYY-MM-DD HH:mm:ss',
+		}),
+		format.errors({ stack: true }),
+		format.splat(),
+		format.json()
+	),
+	defaultMeta: { service: 'arxlive-spotlight-annotator' },
+	transports: [
+		//
+		// - Write to all logs with level `info` and below to `quick-start-combined.log`.
+		// - Write all logs error (and below) to `quick-start-error.log`.
+		//
+		new transports.File({
+			filename: 'logs/error.log',
+			level: 'error',
+		}),
+		new transports.File({ filename: 'logs/all.log' }),
+	],
+});
+
+//
+// If we're not in production then **ALSO** log to the `console`
+// with the colorized simple format.
+//
+if (process.env.NODE_ENV !== 'production') {
+	logger.add(
+		new transports.Console({
+			format: format.combine(format.colorize(), format.simple()),
+		})
+	);
+}


### PR DESCRIPTION
A duplicate snapshot of the arxiv elastic search domain has been created.
This PR introduces new js modules and scripts which annotate the arxiv
abstracts in the duplicate domain using our own Spotlight endpoint.
The script scrolls through every available document, and asynchronously
updates the ES domain with the new entities. The annotations are
performed across 11 confidence intervals (0 to 10 with .1 steps).

closes #2