### PR TITLE
Set dynamic mapping to true

### DIFF
--- a/arxlive_spotlight_annotation/src/test/dbpedia/annotation.test.mjs
+++ b/arxlive_spotlight_annotation/src/test/dbpedia/annotation.test.mjs
@@ -45,7 +45,15 @@ describe('spotlight', () => {
 		const mapping = JSON.parse(
 			await fs.readFile('src/test/conf/test_index_mapping.json')
 		);
-		await createIndex('e2e-test', arxliveCopy, { payload: mapping });
+		await createIndex('e2e-test', arxliveCopy, {
+			payload: {
+				...mapping,
+				mappings: {
+					...mapping.mappings,
+					dynamic: true,
+				},
+			},
+		});
 		const reindexPayload = {
 			source: {
 				index: 'original-arxiv_v6',


### PR DESCRIPTION
This PR fixes #16, by setting the dynamic mapping to true new fields
can be added to the test indices, which are torn down at the end of
testing anyway so will not effect any real processes. This PR makes
the e2e test pass.

fixes #16