### PR TITLE
Delete original-arxiv_v6 index

### DIFF
--- a/arxlive_spotlight_annotation/package.json
+++ b/arxlive_spotlight_annotation/package.json
@@ -32,7 +32,7 @@
 	},
 	"scripts": {
 		"annotate": "cross-env NODE_ENV=production NODE_NO_WARNINGS=1 node src/bin/es/annotate.mjs --field textBody_abstract_article --index arxiv_v6 --spotlight http://localhost:2222/rest/annotate --page-size 100",
-		"rebuildTestIndex": "node src/bin/es/index.mjs delete test && sleep 1 && node src/bin/es/index.mjs create test --path src/test/conf/test_index_mapping.json && sleep 1 && node src/bin/es/index.mjs reindex arxiv_v6 test --max-docs 1000",
+		"rebuildTestIndex": "node src/bin/es/index.mjs delete test && sleep 1 && node src/bin/es/index.mjs create test --path src/test/conf/test_index_mapping.json && sleep 1 && node src/bin/es/index.mjs reindex arxiv_v6 test --ignore dbpedia_entities --max-docs 1000",
 		"rebuildEdgeCasesIndex": "node src/bin/es/index.mjs delete edge-cases && sleep 1 && node src/bin/es/index.mjs create edge-cases && sleep 1 && node src/bin/es/document.mjs create edge-cases ./src/test/data/elastic_search_results/test_documents.json",
 		"rebuild": "npm run rebuildTestIndex && npm run rebuildEdgeCasesIndex",
 		"testAnnotationRemotely": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --index test --spotlight http://localhost:2222/rest/annotate --page-size 10",

--- a/arxlive_spotlight_annotation/src/bin/es/index.mjs
+++ b/arxlive_spotlight_annotation/src/bin/es/index.mjs
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 
 import * as indexAPI from 'es/index.mjs';
 import { arxliveCopy } from 'conf/config.mjs';
+import { remove } from 'es/pipeline.mjs';
 
 const program = new Command();
 
@@ -33,9 +34,15 @@ program
 	.argument('<source>', 'source index')
 	.argument('<dest>', 'destination index')
 	.argument('[domain]', 'domain where index is hosted', arxliveCopy)
+	.option(
+		'--ignore <fields...>',
+		'fields to ignore upon reindex. These fields will not be copied over to the new index.'
+	)
 	.option('--max-docs <docs>', 'number of documents to copy', 'all')
 	.option('--proceed-on-conflict', 'whether to proceed on conflict or abort')
 	.action(async (source, dest, domain, options) => {
+		const pipeline = options.ignore ? await remove(options.ignore) : null;
+		console.log(pipeline);
 		const payload = {
 			...(options.maxDocs !== 'all' && {
 				max_docs: parseInt(options.maxDocs),
@@ -44,6 +51,7 @@ program
 		};
 		await indexAPI.reindex(source, dest, domain, {
 			payload,
+			pipeline,
 		});
 	});
 

--- a/arxlive_spotlight_annotation/src/node_modules/es/index.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/index.mjs
@@ -35,16 +35,19 @@ export const count = async (
  * @param {Object} [options.payload={}] - payload for request to index endpoint.
  * @returns {Object} response to the request 
  */
-export const createIndex = async(name, domain=arxliveCopy, { payload = {} } = {} ) => {
+export const createIndex = async (
+	name,
+	domain = arxliveCopy,
+	{ payload = {} } = {}
+) => {
 	const path = name
 	payload = typeof payload !== 'string' ? JSON.stringify(payload) : payload
 	const request = buildRequest(domain, path, 'PUT', { payload })
 	const { body: response, code } = await makeRequest(request)
 	if (code !== 200) {
-		if (response.error.type === "resource_already_exists_exception") {
-			console.warn("Index already exists, so was not created")
-		}
-		else {
+		if (response.error.type === 'resource_already_exists_exception') {
+			console.warn('Index already exists, so was not created');
+		} else {
 			throw new Error(stringify(response))
 		}
 	}
@@ -77,22 +80,34 @@ export const deleteIndex = async(name, domain=arxliveCopy) => {
  * @param {string} domain - domain on which to perform reindex.
  * @param {Object} [options]
  * @param {Object} [options.payload={}] - payload for request to index endpoint.
+ * @param {string} [options.pipeline=null] - name of the ingestion pipeline to include upon reindex.
  * @returns {Object} response to the request
  */
-export const reindex = async(source, dest, domain=arxliveCopy, { payload = {} } = {} ) => {
+export const reindex = async (
+	source,
+	dest,
+	domain = arxliveCopy,
+	{ payload = {}, pipeline = null } = {}
+) => {
 	const path = '_reindex'
 	payload = typeof payload === 'string' ? JSON.stringify(payload) : payload
 	const expandedPayload = {
 		...payload,
 		source: {
 			index: source
-		}, 
+		},
 		dest: {
-			index: dest
+			index: dest,
+			pipeline,
 		}
 	}
 	const request = buildRequest(domain, path, 'POST', { payload: JSON.stringify(expandedPayload) })
-	const { response } = await makeRequest(request)
+	const { code, body: response } = await makeRequest(request);
+	if (code != 200) {
+		throw new Error(
+			`Reindex from ${source} to ${dest} failed. Response:\n${response}`
+		);
+	}
 	return response;
 }
 /**
@@ -118,7 +133,11 @@ export const getMappings = async (domain, index = arxliveCopy) => {
  * @param {Object} [options.payload={}] - payload for request.
  * @returns {Object} response object.
  */
-export const updateMapping = async (domain, index = arxliveCopy, { payload }) => {
+export const updateMapping = async (
+	domain,
+	index = arxliveCopy,
+	{ payload }
+) => {
 	const path = `${index}/_mappings`
 	const request = buildRequest(domain, path, 'PUT', { payload })
 	const { body: response } = await makeRequest(request);

--- a/arxlive_spotlight_annotation/src/node_modules/es/pipeline.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/pipeline.mjs
@@ -1,0 +1,45 @@
+import { buildRequest, makeRequest } from 'es/requests.mjs';
+import { arxliveCopy } from 'conf/config.mjs';
+
+/**
+ *
+ * @param {string} name - name of pipeline in url parsable form.
+ * @param {string} description - description of pipeline.
+ * @param {Array<Object>} processors - list of processors for pipeline.
+ * @param {string} domain - domain on which to put pipeline.
+ * @returns {Object} response object.
+ */
+const generic = (name, description, processors, domain) => {
+	const path = `_ingest/pipeline/${name}`;
+	const payload = { description, processors };
+
+	const request = buildRequest(domain, path, 'PUT', { payload });
+	return makeRequest(request);
+};
+
+/**
+ *
+ * @param {Array<string>} fields - list of fields to remove upon ingestion.
+ * @param {string} domain - domain on which to put pipeline.
+ * @returns {string} name of created pipeline
+ */
+export const remove = async (fields, domain = arxliveCopy) => {
+	const description = `Remove ${fields.join(' ')}`;
+	const name = `remove-${fields.join('-')}`;
+	const processors = [
+		{
+			remove: {
+				field: fields,
+				ignore_failure: true,
+			},
+		},
+	];
+	const response = await generic(name, description, processors, domain);
+	if (response.code === 200) {
+		return name;
+	} else {
+		throw new Error(
+			`Failed to create remove pipeline. Response:\n${response}`
+		);
+	}
+};

--- a/elasticSearch/datavis-arxlive-copy/snapshots/snapshot_v2/README.md
+++ b/elasticSearch/datavis-arxlive-copy/snapshots/snapshot_v2/README.md
@@ -1,0 +1,7 @@
+This snapshot contains the new state of the domain, where the
+`original-arxiv_v6` has been deleted. It also contains `arxiv_v6`, which is
+annotated, but which does _not_ have the `token_count` analyser for the
+`textBody_article_abstract` field.
+
+See https://github.com/nestauk/dap_dv_backends/issues/21 for reasoning, and
+https://github.com/nestauk/dap_dv_backends/pull/22 for changes introduced.


### PR DESCRIPTION
This PR documents the change of the datavis-arxlive-copy domain on ES.
In particular, documents the removal of the original-arxiv_v6 index. An
associated snapshot is saved for reference. Also included is the
addition of the pipeline API, which is needed so we can use the arxiv_v6
index to reindex a test index. The pipeline API allows the removal of
fields while using the reindex file, which is needed so we can ignore
previously annotated data when testing.

closes #21