### PR TITLE
Change mapping to count word tokens for abstracts

### DIFF
--- a/elasticSearch/datavis-arxlive-copy/snapshots/snapshot_v3/README.md
+++ b/elasticSearch/datavis-arxlive-copy/snapshots/snapshot_v3/README.md
@@ -1,0 +1,32 @@
+This snapshot contains a version of arxiv_v6 that tokenises the
+`textBody_abstract_field` upon ingestion. This was performed so as to use the
+length of tokens when performing data quality aggregations. Specifically, we
+want to be able to normalise the number of high confidence entities annotated by
+the number of tokens, to get an idea of how many of these entities are being
+annotated compared to how many words are present in the abstract.
+
+The following has been added to the mapping for the `textBody_abstract_field`:
+
+```json
+"tokens": {
+    "type": "token_count",
+    "analyzer": "standard"
+}
+```
+
+The mapping now looks like:
+
+```json
+"textBody_abstract_article": {
+    "type": "text",
+    "fields": {
+        "keyword": {
+            "type": "keyword"
+        },
+        "tokens": {
+            "type": "token_count",
+            "analyzer": "standard"
+        }
+    }
+}
+```

--- a/elasticSearch/datavis-arxlive-copy/snapshots/snapshot_v3/arxiv_v6.mapping.json
+++ b/elasticSearch/datavis-arxlive-copy/snapshots/snapshot_v3/arxiv_v6.mapping.json
@@ -1,0 +1,173 @@
+{
+	"settings": {
+		"analysis": {
+			"analyzer": {
+				"terms_analyzer": {
+					"filter": ["lowercase", "stop"],
+					"type": "custom",
+					"tokenizer": "standard"
+				}
+			}
+		}
+	},
+	"mappings": {
+		"dynamic": "strict",
+		"properties": {
+			"booleanFlag_multinational_article": {
+				"type": "boolean"
+			},
+			"count_citations_article": {
+				"type": "integer"
+			},
+			"date_created_article": {
+				"type": "date"
+			},
+			"dbpedia_entities": {
+				"type": "nested",
+				"properties": {
+					"URI": {
+						"type": "text"
+					},
+					"confidence": {
+						"type": "float"
+					},
+					"percentageOfSecondRank": {
+						"type": "float"
+					},
+					"similarityScore": {
+						"type": "float"
+					},
+					"surfaceForm": {
+						"type": "text"
+					}
+				}
+			},
+			"id_digitalObjectIdentifier_article": {
+				"type": "keyword"
+			},
+			"json_category_article": {
+				"type": "nested",
+				"properties": {
+					"ancestors": {
+						"type": "keyword"
+					},
+					"level": {
+						"type": "integer"
+					},
+					"order": {
+						"type": "integer"
+					},
+					"value": {
+						"type": "keyword"
+					}
+				}
+			},
+			"json_fieldsOfStudy_article": {
+				"type": "nested",
+				"properties": {
+					"ancestors": {
+						"type": "keyword"
+					},
+					"level": {
+						"type": "integer"
+					},
+					"order": {
+						"type": "integer"
+					},
+					"value": {
+						"type": "keyword"
+					}
+				}
+			},
+			"json_location_article": {
+				"type": "nested",
+				"properties": {
+					"ancestors": {
+						"type": "keyword"
+					},
+					"level": {
+						"type": "integer"
+					},
+					"order": {
+						"type": "integer"
+					},
+					"value": {
+						"type": "keyword"
+					}
+				}
+			},
+			"metric_citations_article": {
+				"type": "float"
+			},
+			"metric_novelty_article": {
+				"type": "float"
+			},
+			"terms_authors_article": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword"
+					}
+				},
+				"analyzer": "terms_analyzer"
+			},
+			"terms_institutes_article": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword"
+					}
+				},
+				"analyzer": "terms_analyzer"
+			},
+			"terms_tokens_article": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword"
+					}
+				},
+				"analyzer": "terms_analyzer"
+			},
+			"textBody_abstract_article": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword"
+					},
+					"tokens": {
+						"type": "token_count",
+						"analyzer": "standard"
+					}
+				}
+			},
+			"title_of_article": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword"
+					}
+				}
+			},
+			"type_of_entity": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword"
+					}
+				}
+			},
+			"url_of_article": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword"
+					}
+				}
+			},
+			"year_of_article": {
+				"type": "integer"
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR documents the need to change the `arxiv_v6` mapping so that the
token count for the `textBody_abstract_article` is computed on
ingestion. This meant we had to first reindex the `arxiv_v6` index to
another, temporary index, and then delete the old `arxiv_v6` index. Once
the reindexing had finished, we could reindex back to a new index named
`arxiv_v6` and delete the temporary index. A cumbersome and lengthy
process, but the only one that appears to work for computing analyzers
on existing indices.

For clarity, the process looks like:

reindex a -> b (with new mapping)
delete a
reindex b -> a (to rename)
delete b

closes #19 