### PR TITLE
Force flag allows proceed when field exists

### DIFF
--- a/arxlive_spotlight_annotation/package.json
+++ b/arxlive_spotlight_annotation/package.json
@@ -36,7 +36,7 @@
 		"rebuildEdgeCasesIndex": "node src/bin/es/index.mjs delete edge-cases && sleep 1 && node src/bin/es/index.mjs create edge-cases && sleep 1 && node src/bin/es/document.mjs create edge-cases ./src/test/data/elastic_search_results/test_documents.json",
 		"rebuild": "npm run rebuildTestIndex && npm run rebuildEdgeCasesIndex",
 		"testAnnotationRemotely": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --index test --spotlight http://localhost:2222/rest/annotate --page-size 10",
-		"testAnnotationLocally": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --index test --page-size 10",
+		"testAnnotationLocally": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --name dbpedia_entities --index test --page-size 10 --force",
 		"testEdgeCasesLocally": "npm run rebuildEdgeCasesIndex && sleep 1 && mocha --recursive -g 'edgeCases' src/test",
 		"testPerformance": "bash src/test/perf/time.sh",
 		"testSpotlightLocally": "sh src/test/dbpedia/localCurlRequest.sh",

--- a/arxlive_spotlight_annotation/src/bin/es/annotate.mjs
+++ b/arxlive_spotlight_annotation/src/bin/es/annotate.mjs
@@ -51,6 +51,7 @@ program.option(
 	'--force',
 	'Force the annotation process, even if no snapshots can be created'
 );
+
 program.parse();
 const options = program.opts();
 
@@ -68,7 +69,10 @@ const main = async () => {
 
 	const newFieldName = options.name || `dbpedia_entities-${options.field}`;
 	const currentMapping = await getMappings(options.domain, options.index);
-	if (newFieldName in currentMapping[options.index].mappings.properties) {
+	if (
+		newFieldName in currentMapping[options.index].mappings.properties &&
+		!options.force
+	) {
 		throw new Error(
 			'Field already exists at index mapping, and force flag or continue flag not supplied'
 		);

--- a/arxlive_spotlight_annotation/src/bin/es/index.mjs
+++ b/arxlive_spotlight_annotation/src/bin/es/index.mjs
@@ -42,7 +42,6 @@ program
 	.option('--proceed-on-conflict', 'whether to proceed on conflict or abort')
 	.action(async (source, dest, domain, options) => {
 		const pipeline = options.ignore ? await remove(options.ignore) : null;
-		console.log(pipeline);
 		const payload = {
 			...(options.maxDocs !== 'all' && {
 				max_docs: parseInt(options.maxDocs),

--- a/arxlive_spotlight_annotation/src/node_modules/es/requests.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/requests.mjs
@@ -5,8 +5,6 @@ import sha256 from '@aws-crypto/sha256-browser';
 import { HttpRequest } from '@aws-sdk/protocol-http';
 const { Sha256 } = sha256;
 
-import { logger } from 'logging/logging.mjs';
-
 const signer = new SignatureV4({
 	credentials: defaultProvider(),
 	region: 'eu-west-2',

--- a/arxlive_spotlight_annotation/src/node_modules/es/snapshot.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/snapshot.mjs
@@ -13,7 +13,7 @@ const settings = globalSettings.snapshotSettings;
  * @param {string} repository - name of repository to register.
  * @returns {Object} reponse of request.
  */
-export const register = async (domain, repository) => {
+export const register = (domain, repository) => {
 	const path = `_snapshot/${repository}`;
 	const payload = {
 		type: 's3',
@@ -24,8 +24,7 @@ export const register = async (domain, repository) => {
 		},
 	};
 	const request = buildRequest(domain, path, 'PUT', { payload });
-	const { body: response } = await makeRequest(request, { verbose: true });
-	return response;
+	return makeRequest(request, { verbose: true });
 };
 
 /**
@@ -37,11 +36,10 @@ export const register = async (domain, repository) => {
  * @param {string} snapshot - name of the snapshot.
  * @returns {Object} response of request.
  */
-export const trigger = async (domain, repository, snapshot) => {
+export const trigger = (domain, repository, snapshot) => {
 	const path = `_snapshot/${repository}/${snapshot}`;
 	const request = buildRequest(domain, path, 'PUT');
-	const { body: response } = await makeRequest(request, { verbose: true });
-	return response;
+	makeRequest(request, { verbose: true });
 };
 
 /**
@@ -51,11 +49,10 @@ export const trigger = async (domain, repository, snapshot) => {
  * @param {string} repository - repository in which to list the snapshots.
  * @returns {Object} response object, containng the list of snapshots.
  */
-export const list = async (domain, repository) => {
+export const list = (domain, repository) => {
 	const path = repository ? `_snapshot/${repository}/_all` : '_snapshot';
 	const request = buildRequest(domain, path, 'GET');
-	const { body: response } = await makeRequest(request, { verbose: true });
-	return response;
+	return makeRequest(request, { verbose: true });
 };
 
 /**
@@ -67,12 +64,11 @@ export const list = async (domain, repository) => {
  * @param {string} snapshot - name of snapshot used to restore.
  * @returns {Object} response of request.
  */
-export const restore = async (domain, repository, snapshot) => {
+export const restore = (domain, repository, snapshot) => {
 	const payload = { indices: '-.kibana*,-.opendistro*' };
 	const path = `_snapshot/${repository}/${snapshot}/_restore`;
 	const request = buildRequest(domain, path, 'POST', { payload });
-	const { body: response } = await makeRequest(request, { verbose: true });
-	return response;
+	return makeRequest(request, { verbose: true });
 };
 
 /**
@@ -81,9 +77,8 @@ export const restore = async (domain, repository, snapshot) => {
  * @param {string} domain - domain on which to retrieve status.
  * @returns response object containing snapshot status of specified domain.
  */
-export const status = async (domain) => {
+export const status = domain => {
 	const path = '_snapshot/_status';
 	const request = buildRequest(domain, path, 'GET');
-	const { body: response } = await makeRequest(request, { verbose: true });
-	return response;
+	return makeRequest(request, { verbose: true });
 };


### PR DESCRIPTION
Supplying the force flag to arxlive_spotlight_annotation/src/bin/es/annotate.mjs
will now allow the script to continue, regardless of whether the
supplied field argument exists on the index's mapping or not.

This then allows the testAnnotationLocally npm script to name the
annotated field 'dbpedia_entities', which will mimic the arxiv_v6
schema so that the test index and arxiv_6 index can be queried using
the exact same request bodies.

closes #24

Also:
- cleanup arxlive_spotlight_annotation/src/bin/es/index.mjs (remove console.logs)
- cleanup arxlive_spotlight_annotation/src/node_modules/conf/mappings.mjs (remove redundant fields)
- cleanup arxlive_spotlight_annotation/src/node_modules/es/requests.mjs (remove stale imports)
- cleanup arxlive_spotlight_annotation/src/node_modules/es/snapshot.mjs (return request object instead of request body)