### PR TITLE
Get docs with missing `dbpedia_entities` field

### DIFF
--- a/arxlive_spotlight_annotation/dataQuality/aggs/docsWithMissingDBpediaEntitiesField/README.md
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/docsWithMissingDBpediaEntitiesField/README.md
@@ -1,0 +1,22 @@
+## Documents missing the `dbpedia_entities` Field
+
+This query uses a combination of the nested, bool, must_not and exists API
+parameters to determine which documents are missing the `dbpedia_entities`
+field.
+
+Endpoint: `POST arxiv_v6/_count`
+
+See:
+
+- https://www.elastic.co/guide/en/elasticsearch/reference/7.4/nested.html
+- https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl-exists-query.html
+- https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl-bool-query.html
+
+### Notes
+
+We are using the query API because we can't use the `missing` Aggregation API as
+it does not support `nested` type fields.
+
+See:
+
+- https://github.com/elastic/elasticsearch/issues/9571

--- a/arxlive_spotlight_annotation/dataQuality/aggs/docsWithMissingDBpediaEntitiesField/request.json
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/docsWithMissingDBpediaEntitiesField/request.json
@@ -1,0 +1,16 @@
+{
+    "query": {
+        "bool": {
+            "must_not": {
+                "nested": {
+                    "path": "dbpedia_entities",
+                    "query": {
+                        "exists": {
+                            "field": "dbpedia_entities"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/arxlive_spotlight_annotation/dataQuality/aggs/docsWithMissingDBpediaEntitiesField/response.json
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/docsWithMissingDBpediaEntitiesField/response.json
@@ -1,0 +1,9 @@
+{
+    "count": 15,
+    "_shards": {
+        "total": 5,
+        "successful": 5,
+        "skipped": 0,
+        "failed": 0
+    }
+}

--- a/arxlive_spotlight_annotation/dataQuality/aggs/flattenedConfidenceExtendedStats/README.md
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/flattenedConfidenceExtendedStats/README.md
@@ -5,6 +5,8 @@ max, etc. for`confidence`values. Flattened here denotes the fact
 that all annotated entities are treated as a flat list - no per document
 analysis is performed.
 
+Endpoint: `POST arxiv_v6/_search`
+
 See:
 
 - https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-aggregations-metrics-extendedstats-aggregation.html

--- a/arxlive_spotlight_annotation/dataQuality/aggs/flattenedConfidenceHistogram/README.md
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/flattenedConfidenceHistogram/README.md
@@ -5,6 +5,8 @@ the 10 possible `confidence` levels annotated. Flattened here denotes the fact
 that all annotated entities are treated as a flat list - no per document
 analysis is performed.
 
+Endpoint: `POST arxiv_v6/_search`
+
 See:
 
 - https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-aggregations-bucket-terms-aggregation.html

--- a/arxlive_spotlight_annotation/dataQuality/aggs/flattenedSimilarityScoreExtendedStats/README.md
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/flattenedSimilarityScoreExtendedStats/README.md
@@ -5,6 +5,8 @@ max, etc. for `similarityScore` fields. Flattened here denotes the fact
 that all annotated entities are treated as a flat list - no per document
 analysis is performed.
 
+Endpoint: `POST arxiv_v6/_search`
+
 See:
 
 - https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-aggregations-metrics-extendedstats-aggregation.html

--- a/arxlive_spotlight_annotation/dataQuality/aggs/flattenedSimilarityScoreHistogram/README.md
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/flattenedSimilarityScoreHistogram/README.md
@@ -4,6 +4,8 @@ Aggregates all `similarityScore` values into a histogram, each bucket having an
 interval of 0.1. Flattened here denotes the fact that all annotated entities are
 treated as a flat list - no per document analysis is performed.
 
+Endpoint: `POST arxiv_v6/_search`
+
 See:
 
 - https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-aggregations-metrics-extendedstats-aggregation.html

--- a/elasticSearch/conf.json
+++ b/elasticSearch/conf.json
@@ -1,0 +1,9 @@
+[
+	{
+		"domain": "https://search-datavis-arxlive-copy-n6ltva3lqh7x7xb6ucpaqfb5a4.eu-west-2.es.amazonaws.com",
+		"id": "datavis-arxlive-copy",
+		"indices": [
+			"arxiv_v6"
+		]
+	}
+]


### PR DESCRIPTION
See README.md for more detail.

closes #32