### PR TITLE
Add metadata upon ingestion and reindex domain

### DIFF
--- a/arxlive_spotlight_annotation/package.json
+++ b/arxlive_spotlight_annotation/package.json
@@ -36,7 +36,7 @@
 		"rebuildEdgeCasesIndex": "node src/bin/es/index.mjs delete edge-cases && sleep 1 && node src/bin/es/index.mjs create edge-cases && sleep 1 && node src/bin/es/document.mjs create edge-cases ./src/test/data/elastic_search_results/test_documents.json",
 		"rebuild": "npm run rebuildTestIndex && npm run rebuildEdgeCasesIndex",
 		"testAnnotationRemotely": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --index test --spotlight http://localhost:2222/rest/annotate --page-size 10",
-		"testAnnotationLocally": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --name dbpedia_entities --index test --page-size 10 --force",
+		"testAnnotationLocally": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --name dbpedia_entities --index test --page-size 10 --include-metadata",
 		"testEdgeCasesLocally": "npm run rebuildEdgeCasesIndex && sleep 1 && mocha --recursive -g 'edgeCases' src/test",
 		"testPerformance": "bash src/test/perf/time.sh",
 		"testSpotlightLocally": "sh src/test/dbpedia/localCurlRequest.sh",

--- a/arxlive_spotlight_annotation/src/node_modules/conf/config.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/conf/config.mjs
@@ -23,7 +23,7 @@ export const defaultMapping = {
 			type: 'text',
 		},
 		confidence: {
-			type: 'float',
+			type: 'integer',
 		},
 		percentageOfSecondRank: {
 			type: 'float',
@@ -34,5 +34,69 @@ export const defaultMapping = {
 		surfaceForm: {
 			type: 'text',
 		},
+		duplicates_60: {
+			type: 'integer',
+		},
+		duplicates_10: {
+			type: 'integer',
+		}
 	},
 };
+
+export const metaDataMapping = {
+	properties: {
+		confidence_avg: {
+			type: 'float'
+		},
+		confidence_max: {
+			type: 'integer'
+		},
+		confidence_min: {
+			type: 'integer'
+		},
+		entities_count: {
+			type: 'integer'
+		},
+		dupes_ratio: {
+			type: 'float'
+		},
+		confidence_counts: {
+			properties: {
+				"0": {
+					type: 'integer'
+				},
+				"10": {
+					type: 'integer'
+				},
+				"20": {
+					type: 'integer'
+				},
+				"30": {
+					type: 'integer'
+				},
+				"40": {
+					type: 'integer'
+				},
+				"50": {
+					type: 'integer'
+				},
+				"60": {
+					type: 'integer'
+				},
+				"70": {
+					type: 'integer'
+				},
+				"80": {
+					type: 'integer'
+				},
+				"90": {
+					type: 'integer'
+				},
+				"100": {
+					type: 'integer'
+				}
+			}
+		}
+	}
+
+}

--- a/arxlive_spotlight_annotation/src/node_modules/dbpedia/spotlight.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/dbpedia/spotlight.mjs
@@ -3,9 +3,7 @@ import { fetch } from 'undici';
 
 import { update } from 'es/update.mjs';
 import { spotlightEndpoint, confidenceValues } from 'conf/config.mjs';
-import { uniquesByStringifiedObjectValues } from '../util.mjs'; // FIXME not the way we want to import
-import { stringify } from '@svizzle/utils';
-
+import { getLength, mergeWithMerge, stringify } from '@svizzle/utils';
 /**
  * The resource object that the spotlight tool responds with. Each resource corresponds to a DBpedia URI.
  * @typedef SpotlightResource
@@ -43,20 +41,20 @@ const castAnnotation = (annotation) => {
 	// FIXME: Use mapping to determine which types to cast
 	const Resources = annotation.Resources
 		? annotation.Resources.map((r) => {
-				return {
-					...r,
-					'@support': parseInt(r['@support']),
-					'@offset': parseFloat(r['@offset']),
-					'@similarityScore': parseFloat(r['@similarityScore']),
-					'@percentageOfSecondRank': parseFloat(
-						r['@percentageOfSecondRank']
-					),
-				};
-		  })
+			return {
+				...r,
+				'@support': parseInt(r['@support']),
+				'@offset': parseFloat(r['@offset']),
+				'@similarityScore': parseFloat(r['@similarityScore']),
+				'@percentageOfSecondRank': parseFloat(
+					r['@percentageOfSecondRank']
+				),
+			};
+		})
 		: null;
 	return {
 		...annotation,
-		'@confidence': parseFloat(annotation['@confidence']),
+		'@confidence': parseInt(100 * parseFloat(annotation['@confidence'])),
 		'@support': parseInt(annotation['@support']),
 		Resources,
 	};
@@ -117,23 +115,16 @@ export const annotate = async (
  * @param {SpotlightAnnotation} spotlightAnnotation - an object returned by {@link annotate}
  * @returns {ParsedAnnotation} parsed Annotation.
  */
-export const parseAnnotationResults = (spotlightAnnotation) => {
-	const resultSubset = spotlightAnnotation.Resources
-		? spotlightAnnotation.Resources.map((result) => {
-				return {
-					URI: result['@URI'],
-					surfaceForm: result['@surfaceForm'],
-					similarityScore: result['@similarityScore'],
-					percentageOfSecondRank: result['@percentageOfSecondRank'],
-				};
-		  })
+export const parseAnnotationResults = spotlightAnnotation =>
+	spotlightAnnotation.Resources
+		? _.flatMap(spotlightAnnotation.Resources, result => ({
+			confidence: spotlightAnnotation['@confidence'],
+			URI: result['@URI'],
+			surfaceForm: result['@surfaceForm'],
+			similarityScore: result['@similarityScore'],
+			percentageOfSecondRank: result['@percentageOfSecondRank'],
+		}))
 		: [];
-
-	return {
-		confidence: spotlightAnnotation['@confidence'],
-		results: resultSubset,
-	};
-};
 
 /**
  * The final form of resource, this is the same as {@link ReducedResource}, however
@@ -154,21 +145,65 @@ export const parseAnnotationResults = (spotlightAnnotation) => {
  * @param {Object.<string, ParsedAnnotation>} parsedAnnotationByConfidence - an object where {@link ReducedResource} objects are mapped by the condience with which they were produced.
  * @returns {DBpediaEntity[]} - a list of annotated entities.
  */
-export const reduceAnnotationResults = (parsedAnnotationByConfidence) => {
-	const seen = new Set();
-	const confidenceKeys = confidenceValues.map(n => n.toFixed(1)).reverse();
-	const reducedTerms = confidenceKeys.reduce((prev, confidence) => {
-		const terms = parsedAnnotationByConfidence[confidence] || [];
-		const unseenTerms = terms.filter((term) => !seen.has(term.URI));
-		return prev.concat(
-			unseenTerms.map((term) => {
-				seen.add(term.URI);
-				return { ...term, confidence: parseFloat(confidence) };
-			})
-		);
-	}, []);
-	const uniqueTerms = uniquesByStringifiedObjectValues(reducedTerms);
-	return uniqueTerms;
+export const reduceAnnotationResults = spotlightTerms => {
+
+	const reduceTerms = _.mapValuesWith(
+		_.reduceWith(
+			(acc, curr) => curr.confidence > acc.confidence ? curr : acc,
+		)
+	)
+
+	const countDuplicatesOf = confidence => _.mapValuesWith(
+		_.pipe([
+			_.filterWith(_.hasKeyValue('confidence', confidence)),
+			getLength,
+			value => ({ [`duplicates_${confidence}`]: value })
+		]),
+	)
+
+	const reduceAndCountDuplicates = confidences => _.pipe([
+		_.groupBy(_.getKey('URI')),
+		_.collect([
+			reduceTerms,
+			..._.map(confidences, countDuplicatesOf)
+		]),
+		_.reduceWith(mergeWithMerge),
+		_.values
+	])
+
+	const reduceAndCountDuplicatesOf = reduceAndCountDuplicates([10, 60])
+	const finalResults = reduceAndCountDuplicatesOf(spotlightTerms)
+	return finalResults
+};
+
+
+export const annotateText = async (
+	text,
+	{ endpoint = spotlightEndpoint, includeMetaData = null } = {}
+) => {
+	const spotLightPromises = _.map(confidenceValues, confidence =>
+		annotate(text, confidence, { endpoint, })
+	);
+
+	/** @type {SpotlightAnnotation[]} */
+	const spotlightResults = (await Promise.all(spotLightPromises)).filter(
+		(r) => 'Resources' in r
+	);
+
+	/** @type {ParsedAnnotation[]} */
+	const reducedTerms = _.pipe([
+		_.mapWith(parseAnnotationResults),
+		_.flatten,
+		reduceAnnotationResults
+	])(spotlightResults)
+
+	const metadata =
+		includeMetaData && generateMetaData(reducedTerms, spotlightResults);
+
+	return {
+		annotations: reducedTerms,
+		...(metadata && { metadata }),
+	};
 };
 
 /**
@@ -190,31 +225,10 @@ export const reduceAnnotationResults = (parsedAnnotationByConfidence) => {
 export const annotateDocument = async (
 	doc,
 	field,
-	endpoint = spotlightEndpoint
+	{ includeMetaData = null, endpoint = spotlightEndpoint } = {}
 ) => {
-	const spotLightPromises = confidenceValues.map((confidence) =>
-		annotate(doc._source[field], confidence, {
-			endpoint,
-		})
-	);
-	
-	/** @type {SpotlightAnnotation[]} */
-	const spotlightResults = (await Promise.all(spotLightPromises)).filter(
-		(r) => 'Resources' in r
-	);
-	/** @type {ParsedAnnotation[]} */
-	const spotlightTerms = spotlightResults.map(parseAnnotationResults);
-
-	const termsByConfidence = spotlightTerms.reduce((map, obj) => {
-		map[obj.confidence] = obj.results;
-		return map;
-	}, {});
-
-	const reducedTerms = reduceAnnotationResults(termsByConfidence);
-	return {
-		document: doc,
-		annotations: reducedTerms,
-	};
+	const annotationData = await annotateText(doc._source[field], { endpoint, includeMetaData });
+	return { id: doc._id, ...annotationData }
 };
 
 /**
@@ -227,8 +241,7 @@ export const annotateDocument = async (
  * @returns {Promise} a promise indicating status of upload process
  */
 export const uploadAnnotatedDocument = async (
-	annotations,
-	id,
+	{ annotations, id, metadata },
 	fieldName,
 	domain,
 	index
@@ -239,5 +252,55 @@ export const uploadAnnotatedDocument = async (
 	}
 	return update(domain, index, id, {
 		[fieldName]: annotations,
+		...(metadata && { [`${fieldName}_metadata`]: metadata }),
 	});
 };
+
+export const generateMetaData = (reducedTerms, spotlightResults) => {
+
+	const metaReducer = (prev, curr) => {
+		return {
+			entities_count: prev.entities_count + 1,
+			confidence_avg: prev.confidence_avg + curr.confidence,
+			confidence_max: curr.confidence > prev.confidence_max ? curr.confidence : prev.confidence_max,
+			confidence_min: curr.confidence < prev.confidence_min ? curr.confidence : prev.confidence_min,
+			dupes_ratio: prev.dupes_ratio + (curr.duplicates_60 > 1),
+			confidence_counts: {
+				...prev.confidence_counts,
+				[curr.confidence]: prev.confidence_counts[curr.confidence]
+					? prev.confidence_counts[curr.confidence] + 1
+					: 1,
+			},
+		};
+	};
+
+	const intialMetaData = {
+		entities_count: 0,
+		confidence_avg: 0,
+		confidence_max: 0,
+		confidence_min: 100,
+		dupes_ratio: 0,
+		confidence_counts: {},
+	};
+	const reducedMetaData = reducedTerms.reduce(metaReducer, intialMetaData);
+	const metadata = {
+		...reducedMetaData,
+		confidence_avg: reducedMetaData.confidence_avg / reducedMetaData.entities_count,
+		dupes_ratio: reducedMetaData.dupes_ratio / reducedMetaData.entities_count
+	}
+	return metadata;
+};
+
+
+const text = `The theory of relativity usually encompasses two interrelated theories by Albert Einstein: special relativity and general relativity, proposed and published in 1905 and 1915, respectively.[1] Special relativity applies to all physical phenomena in the absence of gravity. General relativity explains the law of gravitation and its relation to other forces of nature.[2] It applies to the cosmological and astrophysical realm, including astronomy.[3]
+
+The theory transformed theoretical physics and astronomy during the 20th century, superseding a 200-year-old theory of mechanics created primarily by Isaac Newton.[3][4][5] It introduced concepts including 4-dimensional spacetime as a unified entity of space and time, relativity of simultaneity, kinematic and gravitational time dilation, and length contraction. In the field of physics, relativity improved the science of elementary particles and their fundamental interactions, along with ushering in the nuclear age. With relativity, cosmology and astrophysics predicted extraordinary astronomical phenomena such as neutron stars, black holes, and gravitational waves.[3][4][5]`
+
+const smallerText = `The theory of relativity usually encompasses two interrelated theories by Albert Einstein: special relativity and general relativity, proposed and published in 1905 and 1915, respectively.`
+
+const main = async () => {
+	const result = await annotateText(smallerText);
+	console.log(result);
+}
+
+await main();

--- a/arxlive_spotlight_annotation/src/node_modules/es/index.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/index.mjs
@@ -63,7 +63,7 @@ export const createIndex = async (
  * @param {string} domain - domain on which to delete index.
  * @returns {Object} response to the request
  */
-export const deleteIndex = async(name, domain=arxliveCopy) => {
+export const deleteIndex = async (name, domain = arxliveCopy) => {
 	const path = name
 	const request = buildRequest(domain, path, 'DELETE')
 	const { code } = await makeRequest(request)
@@ -105,7 +105,7 @@ export const reindex = async (
 	const { code, body: response } = await makeRequest(request);
 	if (code != 200) {
 		throw new Error(
-			`Reindex from ${source} to ${dest} failed. Response:\n${response}`
+			`Reindex from ${source} to ${dest} failed. Response:\n${stringify(response)}`
 		);
 	}
 	return response;

--- a/arxlive_spotlight_annotation/src/node_modules/util.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/util.mjs
@@ -8,17 +8,11 @@ export const toLowerString = v => v.toString().toLowerCase()
 
 // tag function to dedent template literals
 export const dedent = _.pipe([
-    _.head, // first argument is strings
-    _.splitBy('\n'),
-    _.mapWith(trim),
-    _.joinWith('\n'),
-    trim 
-])
-
-export const concatenateStringifyObjectValues= _.pipe([
-    _.values,
-    _.mapWith(toLowerString),
-    join
+	_.head, // first argument is strings
+	_.splitBy('\n'),
+	_.mapWith(trim),
+	_.joinWith('\n'),
+	trim
 ])
 
 /* Array Functions */
@@ -34,8 +28,8 @@ export const batch = _.pipe([_batch, _.filterWith(isNotNil)]);
 
 /* Spotlight */
 
-export const uniquesByStringifiedObjectValues =
-    _.uniquesBy(concatenateStringifyObjectValues)
+export const uniquesByURI =
+	_.uniquesBy(_.getKey('URI'))
 
 /* Promises */
 

--- a/arxlive_spotlight_annotation/src/test/conf/test_index_mapping.json
+++ b/arxlive_spotlight_annotation/src/test/conf/test_index_mapping.json
@@ -3,7 +3,10 @@
 		"analysis": {
 			"analyzer": {
 				"terms_analyzer": {
-					"filter": ["lowercase", "stop"],
+					"filter": [
+						"lowercase",
+						"stop"
+					],
 					"type": "custom",
 					"tokenizer": "standard"
 				}
@@ -21,26 +24,6 @@
 			},
 			"date_created_article": {
 				"type": "date"
-			},
-			"dbpedia_entities": {
-				"type": "nested",
-				"properties": {
-					"URI": {
-						"type": "text"
-					},
-					"confidence": {
-						"type": "float"
-					},
-					"percentageOfSecondRank": {
-						"type": "float"
-					},
-					"similarityScore": {
-						"type": "float"
-					},
-					"surfaceForm": {
-						"type": "text"
-					}
-				}
 			},
 			"id_digitalObjectIdentifier_article": {
 				"type": "keyword"


### PR DESCRIPTION
This PR introduces the ability to add metadata to the ES domain if
the user so desires. The metadata in question is documented in the
issue linked to this PR. The PR also documents the changes to the
arxiv_v6 mappings and the different changes made to facilitate
the data quality aggregations currently underway.

closes #47