### PR TITLE
Add extra fields for duplicate counts to metadata

### DIFF
--- a/arxlive_spotlight_annotation/package.json
+++ b/arxlive_spotlight_annotation/package.json
@@ -31,7 +31,7 @@
 		"url": "git+https://github.com/nestauk/dap_dv_backends.git"
 	},
 	"scripts": {
-		"annotate": "cross-env NODE_ENV=production NODE_NO_WARNINGS=1 node src/bin/es/annotate.mjs --field textBody_abstract_article --index arxiv_v6 --spotlight http://localhost:2222/rest/annotate --page-size 100",
+		"annotate": "cross-env NODE_ENV=production NODE_NO_WARNINGS=1 node src/bin/es/annotate.mjs --field textBody_abstract_article --name dbpedia_entities --index arxiv_v6 --spotlight http://localhost:2222/rest/annotate --page-size 100 --include-metadata",
 		"rebuildTestIndex": "node src/bin/es/index.mjs delete test && sleep 1 && node src/bin/es/index.mjs create test --path src/test/conf/test_index_mapping.json && sleep 1 && node src/bin/es/index.mjs reindex arxiv_v6 test --ignore dbpedia_entities --max-docs 1000",
 		"rebuildEdgeCasesIndex": "node src/bin/es/index.mjs delete edge-cases && sleep 1 && node src/bin/es/index.mjs create edge-cases && sleep 1 && node src/bin/es/document.mjs create edge-cases ./src/test/data/elastic_search_results/test_documents.json",
 		"rebuild": "npm run rebuildTestIndex && npm run rebuildEdgeCasesIndex",

--- a/arxlive_spotlight_annotation/src/node_modules/conf/config.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/conf/config.mjs
@@ -57,8 +57,17 @@ export const metaDataMapping = {
 		entities_count: {
 			type: 'integer'
 		},
-		dupes_ratio: {
+		dupes_10_ratio: {
 			type: 'float'
+		},
+		dupes_60_ratio: {
+			type: 'float'
+		},
+		dupes_10_count: {
+			type: 'integer'
+		},
+		dupes_60_count: {
+			type: 'integer'
 		},
 		confidence_counts: {
 			properties: {

--- a/arxlive_spotlight_annotation/src/node_modules/dbpedia/spotlight.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/dbpedia/spotlight.mjs
@@ -264,7 +264,8 @@ export const generateMetaData = (reducedTerms, spotlightResults) => {
 			confidence_avg: prev.confidence_avg + curr.confidence,
 			confidence_max: curr.confidence > prev.confidence_max ? curr.confidence : prev.confidence_max,
 			confidence_min: curr.confidence < prev.confidence_min ? curr.confidence : prev.confidence_min,
-			dupes_ratio: prev.dupes_ratio + (curr.duplicates_60 > 1),
+			dupes_10_count: prev.dupes_10_count + curr.duplicates_10 > 1 ? 1 : 0,
+			dupes_60_count: prev.dupes_60_count + curr.duplicates_60 > 1 ? 1 : 0,
 			confidence_counts: {
 				...prev.confidence_counts,
 				[curr.confidence]: prev.confidence_counts[curr.confidence]
@@ -279,28 +280,16 @@ export const generateMetaData = (reducedTerms, spotlightResults) => {
 		confidence_avg: 0,
 		confidence_max: 0,
 		confidence_min: 100,
-		dupes_ratio: 0,
+		dupes_10_count: 0,
+		dupes_60_count: 0,
 		confidence_counts: {},
 	};
 	const reducedMetaData = reducedTerms.reduce(metaReducer, intialMetaData);
 	const metadata = {
 		...reducedMetaData,
 		confidence_avg: reducedMetaData.confidence_avg / reducedMetaData.entities_count,
-		dupes_ratio: reducedMetaData.dupes_ratio / reducedMetaData.entities_count
+		dupes_10_ratio: reducedMetaData.dupes_10_count / reducedMetaData.entities_count,
+		dupes_60_ratio: reducedMetaData.dupes_60_count / reducedMetaData.entities_count
 	}
 	return metadata;
 };
-
-
-const text = `The theory of relativity usually encompasses two interrelated theories by Albert Einstein: special relativity and general relativity, proposed and published in 1905 and 1915, respectively.[1] Special relativity applies to all physical phenomena in the absence of gravity. General relativity explains the law of gravitation and its relation to other forces of nature.[2] It applies to the cosmological and astrophysical realm, including astronomy.[3]
-
-The theory transformed theoretical physics and astronomy during the 20th century, superseding a 200-year-old theory of mechanics created primarily by Isaac Newton.[3][4][5] It introduced concepts including 4-dimensional spacetime as a unified entity of space and time, relativity of simultaneity, kinematic and gravitational time dilation, and length contraction. In the field of physics, relativity improved the science of elementary particles and their fundamental interactions, along with ushering in the nuclear age. With relativity, cosmology and astrophysics predicted extraordinary astronomical phenomena such as neutron stars, black holes, and gravitational waves.[3][4][5]`
-
-const smallerText = `The theory of relativity usually encompasses two interrelated theories by Albert Einstein: special relativity and general relativity, proposed and published in 1905 and 1915, respectively.`
-
-const main = async () => {
-	const result = await annotateText(smallerText);
-	console.log(result);
-}
-
-await main();


### PR DESCRIPTION
PR to add extra fields to count both types of duplicates (one for
confidence 10 and the other for confidence 60)

closes #55