### PR TITLE
Flattened URI terms filtered by confidence

### DIFF
--- a/arxlive_spotlight_annotation/dataQuality/aggs/flattenedURITermsByConfidence/README.md
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/flattenedURITermsByConfidence/README.md
@@ -1,0 +1,12 @@
+## Term aggregation of flattened URI values
+
+Counts the occurrences of the `URI` fields in `dbpedia_entities` at different
+confidence levels and returns the top 100 most frequent values.
+
+Endpoint: `POST arxiv_v6/_search`
+
+See:
+
+- https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-filter-context.html
+- https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-aggregations-bucket-terms-aggregation.html
+- https://www.elastic.co/guide/en/elasticsearch/reference/7.4/nested.html

--- a/arxlive_spotlight_annotation/dataQuality/aggs/flattenedURITermsByConfidence/request.json
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/flattenedURITermsByConfidence/request.json
@@ -1,0 +1,177 @@
+{
+    "size": 0,
+    "aggs": {
+        "dbpedia": {
+            "nested": {
+                "path": "dbpedia_entities"
+            },
+            "aggs": {
+                "top_URI_100": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 100
+                        }
+                    },
+                    "aggs": {
+                        "URIs_100": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_90": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 90
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_80": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 80
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_70": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 70
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_60": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 60
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_50": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 50
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_40": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 40
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_30": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 30
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_20": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 20
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_10": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 10
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                },
+                "top_URI_0": {
+                    "filter": {
+                        "term": {
+                            "dbpedia_entities.confidence": 0
+                        }
+                    },
+                    "aggs": {
+                        "URI": {
+                            "terms": {
+                                "field": "dbpedia_entities.URI",
+                                "size": 100
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/arxlive_spotlight_annotation/dataQuality/aggs/flattenedURITermsByConfidence/response.json
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/flattenedURITermsByConfidence/response.json
@@ -1,0 +1,4522 @@
+{
+    "took": 27918,
+    "timed_out": false,
+    "_shards": {
+        "total": 5,
+        "successful": 5,
+        "skipped": 0,
+        "failed": 0
+    },
+    "hits": {
+        "total": {
+            "value": 10000,
+            "relation": "gte"
+        },
+        "max_score": null,
+        "hits": []
+    },
+    "aggregations": {
+        "dbpedia": {
+            "doc_count": 72963412,
+            "top_URI_40": {
+                "doc_count": 5837048,
+                "URI": {
+                    "doc_count_error_upper_bound": 6086,
+                    "sum_other_doc_count": 3831730,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Temperature",
+                            "doc_count": 90782
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Stochastic_process",
+                            "doc_count": 90009
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Equation",
+                            "doc_count": 72535
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mass",
+                            "doc_count": 68082
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Finite_set",
+                            "doc_count": 61635
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gas",
+                            "doc_count": 44587
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Frequency",
+                            "doc_count": 40473
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dimension",
+                            "doc_count": 37722
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Transport_phenomena",
+                            "doc_count": 33815
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electron_magnetic_moment",
+                            "doc_count": 31470
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electron",
+                            "doc_count": 31456
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computer_simulation",
+                            "doc_count": 30920
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Radius",
+                            "doc_count": 30469
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Perturbation_theory",
+                            "doc_count": 29682
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Particle",
+                            "doc_count": 29553
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Galaxy",
+                            "doc_count": 29356
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Star",
+                            "doc_count": 29331
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Independent_politician",
+                            "doc_count": 29048
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Rotation",
+                            "doc_count": 28352
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Formal_system",
+                            "doc_count": 28046
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Homogeneity_and_heterogeneity",
+                            "doc_count": 26823
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Symmetry",
+                            "doc_count": 26641
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Subset",
+                            "doc_count": 24880
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Absorption_spectroscopy",
+                            "doc_count": 23869
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wave",
+                            "doc_count": 23600
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Correlation",
+                            "doc_count": 23145
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Pi",
+                            "doc_count": 20867
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gauge_theory",
+                            "doc_count": 20767
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gamma_ray",
+                            "doc_count": 20450
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spacetime",
+                            "doc_count": 20439
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thermodynamic_equilibrium",
+                            "doc_count": 19358
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Benchmarking",
+                            "doc_count": 18970
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Pressure",
+                            "doc_count": 18937
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Physical_cosmology",
+                            "doc_count": 18915
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Simulation",
+                            "doc_count": 18569
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectral_line",
+                            "doc_count": 17765
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Finite_field",
+                            "doc_count": 16939
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spin_quantum_number",
+                            "doc_count": 16763
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nonlinear_system",
+                            "doc_count": 16750
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Particle_detector",
+                            "doc_count": 16487
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Atomic_nucleus",
+                            "doc_count": 16474
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cosmic_dust",
+                            "doc_count": 16285
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fluid",
+                            "doc_count": 15567
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/World_War_II",
+                            "doc_count": 15275
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Boundary_value_problem",
+                            "doc_count": 15197
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Continuum_mechanics",
+                            "doc_count": 14985
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Shader",
+                            "doc_count": 14748
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Universe",
+                            "doc_count": 14568
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Empirical_evidence",
+                            "doc_count": 14475
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Liquid",
+                            "doc_count": 14193
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Robust_statistics",
+                            "doc_count": 14153
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Photon",
+                            "doc_count": 13898
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Oscillation",
+                            "doc_count": 13861
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fraction",
+                            "doc_count": 13555
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Matrix_decomposition",
+                            "doc_count": 13430
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fluid_dynamics",
+                            "doc_count": 13262
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sensor",
+                            "doc_count": 13186
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cluster_analysis",
+                            "doc_count": 13174
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Omega",
+                            "doc_count": 13147
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Neutrino",
+                            "doc_count": 13092
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Iron",
+                            "doc_count": 13088
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Society_of_Christ",
+                            "doc_count": 12948
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Pi_bond",
+                            "doc_count": 12919
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Macroscopic_scale",
+                            "doc_count": 12772
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Subroutine",
+                            "doc_count": 12434
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Resonance",
+                            "doc_count": 12412
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Astrophysics",
+                            "doc_count": 12241
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Special_functions",
+                            "doc_count": 12149
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Curve",
+                            "doc_count": 11957
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Coulomb's_law",
+                            "doc_count": 11922
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Embedding",
+                            "doc_count": 11912
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectrum",
+                            "doc_count": 11869
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Crystal_structure",
+                            "doc_count": 11726
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Invariant_theory",
+                            "doc_count": 11499
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Modular_programming",
+                            "doc_count": 11408
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Real-time_computing",
+                            "doc_count": 11408
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Asymptotic_analysis",
+                            "doc_count": 11191
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hadron",
+                            "doc_count": 11168
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Parameter",
+                            "doc_count": 11087
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Infinity",
+                            "doc_count": 10882
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Natural_number",
+                            "doc_count": 10690
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Statistical_inference",
+                            "doc_count": 10681
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Continuous_spectrum",
+                            "doc_count": 10680
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Beta_distribution",
+                            "doc_count": 10625
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mathematical_Sciences_Publishers",
+                            "doc_count": 10595
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Perpendicular",
+                            "doc_count": 10476
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Software_architecture",
+                            "doc_count": 10471
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Economic_inequality",
+                            "doc_count": 10345
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Oregon_Department_of_Transportation",
+                            "doc_count": 10324
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Solar_mass",
+                            "doc_count": 10182
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Neutron_cross_section",
+                            "doc_count": 10059
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thermodynamics",
+                            "doc_count": 9805
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Chemical_compound",
+                            "doc_count": 9793
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Planar_graph",
+                            "doc_count": 9753
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fermion",
+                            "doc_count": 9687
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Symmetric_matrix",
+                            "doc_count": 9660
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Organic_compound",
+                            "doc_count": 9534
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Integrable_system",
+                            "doc_count": 9444
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Consistency",
+                            "doc_count": 9417
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectroscopy",
+                            "doc_count": 9323
+                        }
+                    ]
+                }
+            },
+            "top_URI_50": {
+                "doc_count": 3741679,
+                "URI": {
+                    "doc_count_error_upper_bound": 4001,
+                    "sum_other_doc_count": 2132982,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Energy",
+                            "doc_count": 156754
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Symmetry",
+                            "doc_count": 43891
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nonlinear_system",
+                            "doc_count": 40709
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Compact_space",
+                            "doc_count": 38271
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Chronology_of_the_universe",
+                            "doc_count": 36706
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Velocity",
+                            "doc_count": 36265
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dependent_and_independent_variables",
+                            "doc_count": 34530
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Flux",
+                            "doc_count": 34020
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectrum",
+                            "doc_count": 32112
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Noise",
+                            "doc_count": 30992
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Conjecture",
+                            "doc_count": 30558
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Momentum",
+                            "doc_count": 29695
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Differential_equation",
+                            "doc_count": 29165
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Magnetic_field",
+                            "doc_count": 28924
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Amplitude",
+                            "doc_count": 28767
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Evolution",
+                            "doc_count": 28377
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Geometry",
+                            "doc_count": 26133
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Stellar_evolution",
+                            "doc_count": 23449
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Probability",
+                            "doc_count": 23167
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Permutation",
+                            "doc_count": 21601
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Correlation",
+                            "doc_count": 20574
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fender_Wide_Range",
+                            "doc_count": 19580
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Atomic_nucleus",
+                            "doc_count": 17160
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Asymptote",
+                            "doc_count": 16815
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Perturbation_theory",
+                            "doc_count": 16784
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hertz",
+                            "doc_count": 16733
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_entanglement",
+                            "doc_count": 16413
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectral_density",
+                            "doc_count": 16155
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Asymptotic_analysis",
+                            "doc_count": 15232
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Chery",
+                            "doc_count": 15042
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Power_law",
+                            "doc_count": 14702
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Binary_star",
+                            "doc_count": 14524
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fermion",
+                            "doc_count": 14484
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ferromagnetism",
+                            "doc_count": 14382
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Communication",
+                            "doc_count": 13911
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Canadian_dollar",
+                            "doc_count": 13223
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Upper_and_lower_bounds",
+                            "doc_count": 13029
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Coefficient",
+                            "doc_count": 12889
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Eigenvalues_and_eigenvectors",
+                            "doc_count": 12850
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gradient",
+                            "doc_count": 12807
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Invariant_theory",
+                            "doc_count": 12787
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Radio_wave",
+                            "doc_count": 12741
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Order_and_disorder",
+                            "doc_count": 12710
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Statistical_inference",
+                            "doc_count": 12592
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Boson",
+                            "doc_count": 12520
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Astronomical_spectroscopy",
+                            "doc_count": 12389
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Parsec",
+                            "doc_count": 12059
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Finite_strain_theory",
+                            "doc_count": 11446
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Modulation",
+                            "doc_count": 11257
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electronvolt",
+                            "doc_count": 11164
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Black_hole",
+                            "doc_count": 11118
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hybrid_electric_vehicle",
+                            "doc_count": 11084
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Metal",
+                            "doc_count": 11035
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Kinetic_energy",
+                            "doc_count": 10780
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Probability_distribution",
+                            "doc_count": 10724
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ultraviolet",
+                            "doc_count": 10609
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Communication_protocol",
+                            "doc_count": 10568
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Derivative",
+                            "doc_count": 10517
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Chemical_species",
+                            "doc_count": 10348
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Binary_number",
+                            "doc_count": 10345
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Acceleration",
+                            "doc_count": 10164
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computer",
+                            "doc_count": 10010
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Many-body_problem",
+                            "doc_count": 9904
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gravitational_singularity",
+                            "doc_count": 9660
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Length",
+                            "doc_count": 9475
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ring_system",
+                            "doc_count": 9423
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Standard_Model",
+                            "doc_count": 9195
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Kinematics",
+                            "doc_count": 9069
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gravity",
+                            "doc_count": 8818
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Invariant_measure",
+                            "doc_count": 8775
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Deterministic_system",
+                            "doc_count": 8639
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Coating",
+                            "doc_count": 8621
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Linear_elasticity",
+                            "doc_count": 8568
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data_set",
+                            "doc_count": 8261
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quark",
+                            "doc_count": 8250
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Australian_dollar",
+                            "doc_count": 8236
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Yang–Mills_theory",
+                            "doc_count": 8194
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Two-dimensional_space",
+                            "doc_count": 8099
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Parameter_space",
+                            "doc_count": 8027
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nanometre",
+                            "doc_count": 8020
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Molecule",
+                            "doc_count": 7887
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data_communication",
+                            "doc_count": 7686
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Particle_beam",
+                            "doc_count": 7653
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dimension",
+                            "doc_count": 7504
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Leading-order_term",
+                            "doc_count": 7485
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Radio_astronomy",
+                            "doc_count": 7363
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Laser",
+                            "doc_count": 7350
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Exponential_function",
+                            "doc_count": 7064
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Singular_point_of_an_algebraic_variety",
+                            "doc_count": 7017
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cross-interleaved_Reed–Solomon_coding",
+                            "doc_count": 6897
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Degenerate_energy_levels",
+                            "doc_count": 6878
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Distortion",
+                            "doc_count": 6860
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Singlet_state",
+                            "doc_count": 6823
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Molecular_geometry",
+                            "doc_count": 6809
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectroscopy",
+                            "doc_count": 6798
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Linear_subspace",
+                            "doc_count": 6746
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Pound_per_square_inch",
+                            "doc_count": 6697
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Empirical_research",
+                            "doc_count": 6612
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electronic_structure",
+                            "doc_count": 6536
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Neumann_boundary_condition",
+                            "doc_count": 6456
+                        }
+                    ]
+                }
+            },
+            "top_URI_20": {
+                "doc_count": 544441,
+                "URI": {
+                    "doc_count_error_upper_bound": 353,
+                    "sum_other_doc_count": 313030,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Coupling_constant",
+                            "doc_count": 43802
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Amplitude",
+                            "doc_count": 19624
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Astronomical_survey",
+                            "doc_count": 14742
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Prime_number",
+                            "doc_count": 9576
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Survey_methodology",
+                            "doc_count": 8251
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wikipedia",
+                            "doc_count": 7041
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The_Key_(1958_film)",
+                            "doc_count": 6826
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/New_York_City",
+                            "doc_count": 6258
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2007",
+                            "doc_count": 6065
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Coupling",
+                            "doc_count": 6004
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The_Guardian",
+                            "doc_count": 5950
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Angular_momentum_coupling",
+                            "doc_count": 5902
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The",
+                            "doc_count": 5773
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2006",
+                            "doc_count": 5661
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2005",
+                            "doc_count": 5385
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/We",
+                            "doc_count": 4634
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/FA_Cup_Final",
+                            "doc_count": 1898
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Internet",
+                            "doc_count": 1831
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Experiment",
+                            "doc_count": 1802
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Indium",
+                            "doc_count": 1758
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Poland",
+                            "doc_count": 1714
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_method",
+                            "doc_count": 1647
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Holotype",
+                            "doc_count": 1537
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Research",
+                            "doc_count": 1520
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mathematical_model",
+                            "doc_count": 1489
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/New_Testament",
+                            "doc_count": 1448
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Paper",
+                            "doc_count": 1435
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Surface_roughness",
+                            "doc_count": 1402
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_literature",
+                            "doc_count": 1322
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Academic_publishing",
+                            "doc_count": 1252
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mobile_Suit_Gundam_ZZ",
+                            "doc_count": 1209
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sathya_Sai_Baba",
+                            "doc_count": 1197
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Atomic_number",
+                            "doc_count": 1159
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Clinical_trial",
+                            "doc_count": 1120
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Surveying",
+                            "doc_count": 1081
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Schizophrenia",
+                            "doc_count": 1080
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1966_FIFA_World_Cup_Final",
+                            "doc_count": 1078
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Secondary_school",
+                            "doc_count": 1040
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Diffraction_grating",
+                            "doc_count": 1000
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Central_limit_theorem",
+                            "doc_count": 945
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Phonograph_record",
+                            "doc_count": 944
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Region",
+                            "doc_count": 845
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Basionym",
+                            "doc_count": 843
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Conceptual_model",
+                            "doc_count": 841
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Methodology",
+                            "doc_count": 816
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data_type",
+                            "doc_count": 813
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computer_simulation",
+                            "doc_count": 808
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dynasty_(1981_TV_series,_season_7)",
+                            "doc_count": 742
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Prime_ideal",
+                            "doc_count": 734
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Type_system",
+                            "doc_count": 724
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Regions_of_Italy",
+                            "doc_count": 722
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2019_U.S._Poker_Open",
+                            "doc_count": 720
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Film_adaptation",
+                            "doc_count": 719
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Processor_register",
+                            "doc_count": 691
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Theory",
+                            "doc_count": 688
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data",
+                            "doc_count": 681
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Plastic_wrap",
+                            "doc_count": 681
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Italian_language",
+                            "doc_count": 671
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_theory",
+                            "doc_count": 669
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Natural_number",
+                            "doc_count": 648
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Formal_proof",
+                            "doc_count": 637
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thermodynamic_system",
+                            "doc_count": 629
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Number",
+                            "doc_count": 628
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time",
+                            "doc_count": 624
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Circle",
+                            "doc_count": 621
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dynamical_system",
+                            "doc_count": 615
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Structure",
+                            "doc_count": 612
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dimension",
+                            "doc_count": 609
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Addition",
+                            "doc_count": 604
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_modelling",
+                            "doc_count": 595
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Euphoria",
+                            "doc_count": 590
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Business_process",
+                            "doc_count": 585
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Science",
+                            "doc_count": 583
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/System",
+                            "doc_count": 581
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Limit_of_a_sequence",
+                            "doc_count": 575
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Divine_presence",
+                            "doc_count": 570
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Statistical_model",
+                            "doc_count": 568
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The_Lowest",
+                            "doc_count": 567
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Criminal_investigation",
+                            "doc_count": 566
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Estimation_theory",
+                            "doc_count": 566
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Subroutine",
+                            "doc_count": 540
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ice_age",
+                            "doc_count": 534
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Why_(Carly_Simon_song)",
+                            "doc_count": 527
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/New_product_development",
+                            "doc_count": 524
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time_complexity",
+                            "doc_count": 519
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Iterative_method",
+                            "doc_count": 518
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Software_feature",
+                            "doc_count": 517
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Independent_politician",
+                            "doc_count": 510
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Observation",
+                            "doc_count": 506
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Limit_of_a_function",
+                            "doc_count": 505
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Haplogroup_R1a",
+                            "doc_count": 493
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_mechanics",
+                            "doc_count": 492
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Social_group",
+                            "doc_count": 490
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Accounting",
+                            "doc_count": 484
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Crystal_structure",
+                            "doc_count": 482
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dependent_and_independent_variables",
+                            "doc_count": 482
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Technical_standard",
+                            "doc_count": 481
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Estimator",
+                            "doc_count": 479
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Resultant",
+                            "doc_count": 477
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Simple_group",
+                            "doc_count": 468
+                        }
+                    ]
+                }
+            },
+            "top_URI_30": {
+                "doc_count": 51431212,
+                "URI": {
+                    "doc_count_error_upper_bound": 52518,
+                    "sum_other_doc_count": 37431033,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Wikipedia",
+                            "doc_count": 790241
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The",
+                            "doc_count": 522043
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Indium",
+                            "doc_count": 469628
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Experiment",
+                            "doc_count": 441439
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sathya_Sai_Baba",
+                            "doc_count": 415688
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/We",
+                            "doc_count": 379691
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mathematical_model",
+                            "doc_count": 378407
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The_Guardian",
+                            "doc_count": 363802
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Paper",
+                            "doc_count": 254175
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wikimedia_Foundation",
+                            "doc_count": 225014
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Grammatical_case",
+                            "doc_count": 215737
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Research",
+                            "doc_count": 210358
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Internet",
+                            "doc_count": 202848
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Holotype",
+                            "doc_count": 201548
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data",
+                            "doc_count": 198789
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Observation",
+                            "doc_count": 194839
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Addition",
+                            "doc_count": 184320
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Measurement",
+                            "doc_count": 182054
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Order_theory",
+                            "doc_count": 177746
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/For_loop",
+                            "doc_count": 173932
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Political_demonstration",
+                            "doc_count": 168750
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time",
+                            "doc_count": 162282
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Immunization",
+                            "doc_count": 157950
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Iterative_method",
+                            "doc_count": 144297
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Set_theory",
+                            "doc_count": 144098
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Introduced_species",
+                            "doc_count": 142737
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dynamical_system",
+                            "doc_count": 142652
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Probability_distribution",
+                            "doc_count": 142156
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dimension",
+                            "doc_count": 141897
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_method",
+                            "doc_count": 140861
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/General_officer",
+                            "doc_count": 137127
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Flow_velocity",
+                            "doc_count": 135720
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Criminal_investigation",
+                            "doc_count": 126317
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dependent_and_independent_variables",
+                            "doc_count": 125233
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Behavior",
+                            "doc_count": 124529
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Performance",
+                            "doc_count": 121784
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Causality",
+                            "doc_count": 117991
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Prediction",
+                            "doc_count": 117389
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Existence",
+                            "doc_count": 115729
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Accuracy_and_precision",
+                            "doc_count": 113438
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Application_software",
+                            "doc_count": 111882
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Deferent_and_epicycle",
+                            "doc_count": 111832
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Number",
+                            "doc_count": 106847
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Arsenic",
+                            "doc_count": 105587
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Determinism",
+                            "doc_count": 104722
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Logical_consequence",
+                            "doc_count": 104483
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Circle",
+                            "doc_count": 102282
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ternary_fission",
+                            "doc_count": 101178
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data_set",
+                            "doc_count": 100141
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Approximation",
+                            "doc_count": 99929
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mathematical_optimization",
+                            "doc_count": 99868
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Redox",
+                            "doc_count": 96959
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time_complexity",
+                            "doc_count": 93837
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computer_performance",
+                            "doc_count": 93741
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Equation_solving",
+                            "doc_count": 93522
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computer_simulation",
+                            "doc_count": 92453
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Limit_of_a_function",
+                            "doc_count": 92289
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Presentation_of_a_group",
+                            "doc_count": 91899
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Calculation",
+                            "doc_count": 90322
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Group_action",
+                            "doc_count": 89973
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Maxima_and_minima",
+                            "doc_count": 89258
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Integral",
+                            "doc_count": 89172
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Machine_learning",
+                            "doc_count": 88775
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Region",
+                            "doc_count": 87269
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Strong_interaction",
+                            "doc_count": 87221
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Theory",
+                            "doc_count": 87185
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sensitivity_and_specificity",
+                            "doc_count": 87044
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electric_current",
+                            "doc_count": 86820
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Finally_(CeCe_Peniston_album)",
+                            "doc_count": 85910
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Complexity",
+                            "doc_count": 85854
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Necessity_and_sufficiency",
+                            "doc_count": 84567
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computation",
+                            "doc_count": 83981
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Software_development",
+                            "doc_count": 83449
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Expected_value",
+                            "doc_count": 82172
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Schizophrenia",
+                            "doc_count": 80804
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Estimation_theory",
+                            "doc_count": 79016
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Combined_DNA_Index_System",
+                            "doc_count": 77823
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_modelling",
+                            "doc_count": 77565
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Numerical_analysis",
+                            "doc_count": 77523
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_theory",
+                            "doc_count": 77431
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Statistical_model",
+                            "doc_count": 77251
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thermodynamic_system",
+                            "doc_count": 77161
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Formal_proof",
+                            "doc_count": 77077
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Glossary_of_graph_theory",
+                            "doc_count": 76743
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Interaction",
+                            "doc_count": 75849
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Condorcet_paradox",
+                            "doc_count": 74607
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Record_producer",
+                            "doc_count": 73957
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Observational_astronomy",
+                            "doc_count": 73537
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Principle_of_locality",
+                            "doc_count": 73306
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Multiplication",
+                            "doc_count": 71875
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_literature",
+                            "doc_count": 71067
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Codomain",
+                            "doc_count": 70591
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Density",
+                            "doc_count": 68793
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Exponentiation",
+                            "doc_count": 67917
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Evaluation",
+                            "doc_count": 67827
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nature",
+                            "doc_count": 67306
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Equation",
+                            "doc_count": 67086
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Secondary_school",
+                            "doc_count": 66998
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Crystal_structure",
+                            "doc_count": 66846
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Straightedge_and_compass_construction",
+                            "doc_count": 66564
+                        }
+                    ]
+                }
+            },
+            "top_URI_10": {
+                "doc_count": 395070,
+                "URI": {
+                    "doc_count_error_upper_bound": 288,
+                    "sum_other_doc_count": 213062,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/2015",
+                            "doc_count": 7346
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2011",
+                            "doc_count": 6668
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2017",
+                            "doc_count": 6506
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2010",
+                            "doc_count": 6473
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2009",
+                            "doc_count": 6317
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2013",
+                            "doc_count": 6173
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2008",
+                            "doc_count": 6139
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2012",
+                            "doc_count": 5823
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2018",
+                            "doc_count": 5820
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2014",
+                            "doc_count": 5455
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2004",
+                            "doc_count": 5229
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2003",
+                            "doc_count": 4749
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2016",
+                            "doc_count": 4749
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2019",
+                            "doc_count": 4606
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wikipedia",
+                            "doc_count": 3974
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2000",
+                            "doc_count": 3665
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2002",
+                            "doc_count": 3629
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The_Guardian",
+                            "doc_count": 3356
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2020",
+                            "doc_count": 3273
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The",
+                            "doc_count": 3232
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1999",
+                            "doc_count": 3221
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Formal_specification",
+                            "doc_count": 2926
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/We",
+                            "doc_count": 2802
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1998",
+                            "doc_count": 2654
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2001",
+                            "doc_count": 2566
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1997",
+                            "doc_count": 2464
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Systematics",
+                            "doc_count": 2430
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1995",
+                            "doc_count": 2211
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1994",
+                            "doc_count": 1943
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2016_United_States_presidential_election",
+                            "doc_count": 1741
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2000_Summer_Olympics",
+                            "doc_count": 1695
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1993",
+                            "doc_count": 1591
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1992",
+                            "doc_count": 1545
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1990",
+                            "doc_count": 1466
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2001_Canadian_census",
+                            "doc_count": 1348
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1991",
+                            "doc_count": 1341
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Milky",
+                            "doc_count": 1236
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Noether's_theorem",
+                            "doc_count": 1227
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2012_Summer_Olympics",
+                            "doc_count": 1179
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1989",
+                            "doc_count": 1112
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gennes,_Maine-et-Loire",
+                            "doc_count": 1089
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Internet",
+                            "doc_count": 1079
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2000_United_States_presidential_election",
+                            "doc_count": 1050
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1996_Canadian_census",
+                            "doc_count": 1043
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Experiment",
+                            "doc_count": 992
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Poland",
+                            "doc_count": 983
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Indium",
+                            "doc_count": 981
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1996",
+                            "doc_count": 955
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2013_national_electoral_calendar",
+                            "doc_count": 944
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_method",
+                            "doc_count": 926
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1988",
+                            "doc_count": 919
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1980",
+                            "doc_count": 911
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1986",
+                            "doc_count": 909
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Paper",
+                            "doc_count": 869
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1987",
+                            "doc_count": 868
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1985",
+                            "doc_count": 866
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Research",
+                            "doc_count": 828
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mathematical_model",
+                            "doc_count": 821
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1983",
+                            "doc_count": 779
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cumulant",
+                            "doc_count": 771
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Holotype",
+                            "doc_count": 739
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Academic_publishing",
+                            "doc_count": 720
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1981",
+                            "doc_count": 716
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_literature",
+                            "doc_count": 710
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1970",
+                            "doc_count": 700
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1979",
+                            "doc_count": 690
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1982",
+                            "doc_count": 681
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sathya_Sai_Baba",
+                            "doc_count": 678
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1976",
+                            "doc_count": 646
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Schizophrenia",
+                            "doc_count": 643
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1975",
+                            "doc_count": 602
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Clinical_trial",
+                            "doc_count": 600
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Changes_(The_Dresden_Files)",
+                            "doc_count": 594
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1978",
+                            "doc_count": 577
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1977",
+                            "doc_count": 558
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dresselhaus_effect",
+                            "doc_count": 553
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2011_AFL_season",
+                            "doc_count": 548
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2000_AFL_season",
+                            "doc_count": 545
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2021_U.S._Poker_Open",
+                            "doc_count": 529
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1974",
+                            "doc_count": 523
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Secondary_school",
+                            "doc_count": 493
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Region",
+                            "doc_count": 484
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Phonograph_record",
+                            "doc_count": 483
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2016_AFL_season",
+                            "doc_count": 478
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Type_system",
+                            "doc_count": 478
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2014_AFL_season",
+                            "doc_count": 469
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computer_simulation",
+                            "doc_count": 469
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Methodology",
+                            "doc_count": 459
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Conceptual_model",
+                            "doc_count": 456
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1972",
+                            "doc_count": 455
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1998_AFL_season",
+                            "doc_count": 450
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data_type",
+                            "doc_count": 441
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1971",
+                            "doc_count": 434
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2015_AFL_season",
+                            "doc_count": 429
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1969",
+                            "doc_count": 426
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Successful_(song)",
+                            "doc_count": 425
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nineteen_Eighty-Four",
+                            "doc_count": 420
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2002_AFL_season",
+                            "doc_count": 417
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Basionym",
+                            "doc_count": 414
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2013_AFL_season",
+                            "doc_count": 413
+                        }
+                    ]
+                }
+            },
+            "top_URI_0": {
+                "doc_count": 173400,
+                "URI": {
+                    "doc_count_error_upper_bound": 60,
+                    "sum_other_doc_count": 53209,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/To_(film)",
+                            "doc_count": 89629
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Besides_(Over_the_Rhine_album)",
+                            "doc_count": 10132
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Uncover_(song)",
+                            "doc_count": 3326
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wikipedia",
+                            "doc_count": 1275
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The",
+                            "doc_count": 1094
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The_Guardian",
+                            "doc_count": 1085
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/We",
+                            "doc_count": 878
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Meanwhile_(Futurama)",
+                            "doc_count": 595
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Experiment",
+                            "doc_count": 337
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Internet",
+                            "doc_count": 334
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Poland",
+                            "doc_count": 329
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Indium",
+                            "doc_count": 309
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Paper",
+                            "doc_count": 303
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mathematical_model",
+                            "doc_count": 279
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_method",
+                            "doc_count": 271
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_literature",
+                            "doc_count": 249
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Research",
+                            "doc_count": 246
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Holotype",
+                            "doc_count": 236
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sathya_Sai_Baba",
+                            "doc_count": 236
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Academic_publishing",
+                            "doc_count": 213
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Clinical_trial",
+                            "doc_count": 213
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Schizophrenia",
+                            "doc_count": 205
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Polyadenylation",
+                            "doc_count": 186
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computer_simulation",
+                            "doc_count": 166
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_theory",
+                            "doc_count": 163
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data_type",
+                            "doc_count": 161
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Phonograph_record",
+                            "doc_count": 159
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Region",
+                            "doc_count": 158
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Conceptual_model",
+                            "doc_count": 157
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Topmost,_Kentucky",
+                            "doc_count": 150
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Type_system",
+                            "doc_count": 150
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Secondary_school",
+                            "doc_count": 145
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Methodology",
+                            "doc_count": 144
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Basionym",
+                            "doc_count": 141
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Regions_of_Italy",
+                            "doc_count": 141
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Limit_of_a_sequence",
+                            "doc_count": 139
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Theory",
+                            "doc_count": 138
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Formal_proof",
+                            "doc_count": 137
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Plastic_wrap",
+                            "doc_count": 137
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Estimation_theory",
+                            "doc_count": 130
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Italian_language",
+                            "doc_count": 128
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scientific_modelling",
+                            "doc_count": 126
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Circle",
+                            "doc_count": 125
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Data",
+                            "doc_count": 123
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wishing_(DJ_Drama_song)",
+                            "doc_count": 123
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dynamical_system",
+                            "doc_count": 115
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Addition",
+                            "doc_count": 114
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time",
+                            "doc_count": 113
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Business_process",
+                            "doc_count": 112
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Film_adaptation",
+                            "doc_count": 112
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Science",
+                            "doc_count": 112
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Structure",
+                            "doc_count": 112
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dimension",
+                            "doc_count": 111
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Natural_number",
+                            "doc_count": 111
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Accounting",
+                            "doc_count": 109
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Statistical_model",
+                            "doc_count": 109
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/System",
+                            "doc_count": 108
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thermodynamic_system",
+                            "doc_count": 106
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Number",
+                            "doc_count": 103
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Divine_presence",
+                            "doc_count": 101
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Independent_politician",
+                            "doc_count": 100
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Iterative_method",
+                            "doc_count": 100
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Subroutine",
+                            "doc_count": 100
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Distinctive_feature",
+                            "doc_count": 99
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Equation",
+                            "doc_count": 99
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ice_age",
+                            "doc_count": 98
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Criminal_investigation",
+                            "doc_count": 97
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Equation_solving",
+                            "doc_count": 95
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Finite_set",
+                            "doc_count": 95
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Observation",
+                            "doc_count": 95
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Application_software",
+                            "doc_count": 94
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Euphoria",
+                            "doc_count": 94
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time_complexity",
+                            "doc_count": 94
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dependent_and_independent_variables",
+                            "doc_count": 93
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_mechanics",
+                            "doc_count": 92
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Classical_mechanics",
+                            "doc_count": 91
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The_Crab",
+                            "doc_count": 90
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Biophysical_environment",
+                            "doc_count": 89
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Deferent_and_epicycle",
+                            "doc_count": 89
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/New_product_development",
+                            "doc_count": 89
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Resultant",
+                            "doc_count": 89
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Social_group",
+                            "doc_count": 89
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Haplogroup_R1a",
+                            "doc_count": 88
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Simulation",
+                            "doc_count": 87
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Extended_play",
+                            "doc_count": 84
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Measurement",
+                            "doc_count": 84
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Torah_study",
+                            "doc_count": 84
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Chola_dynasty",
+                            "doc_count": 80
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/FA_Cup_Final",
+                            "doc_count": 79
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Existence",
+                            "doc_count": 78
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/1966_FIFA_World_Cup_Final",
+                            "doc_count": 77
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Technical_standard",
+                            "doc_count": 77
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Confirmation",
+                            "doc_count": 76
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Computation",
+                            "doc_count": 73
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Observational_astronomy",
+                            "doc_count": 72
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Proof_theory",
+                            "doc_count": 69
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Weighing_scale",
+                            "doc_count": 67
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Simple_group",
+                            "doc_count": 66
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Systems_theory",
+                            "doc_count": 66
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Software_development",
+                            "doc_count": 64
+                        }
+                    ]
+                }
+            },
+            "top_URI_80": {
+                "doc_count": 1361568,
+                "URI": {
+                    "doc_count_error_upper_bound": 1191,
+                    "sum_other_doc_count": 740458,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Algorithm",
+                            "doc_count": 102299
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Graph_theory",
+                            "doc_count": 28452
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Chirality",
+                            "doc_count": 22927
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Integral",
+                            "doc_count": 18171
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Star_formation",
+                            "doc_count": 18152
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Supersymmetry",
+                            "doc_count": 15064
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dispersion_relation",
+                            "doc_count": 13941
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wavelength",
+                            "doc_count": 12587
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Tongan_paʻanga",
+                            "doc_count": 12219
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectrophotometry",
+                            "doc_count": 11997
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Glossary_of_graph_theory",
+                            "doc_count": 11819
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Antiferromagnetism",
+                            "doc_count": 11775
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Stochastic",
+                            "doc_count": 11634
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Stochastic_process",
+                            "doc_count": 10447
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Brunei_dollar",
+                            "doc_count": 9338
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gauge_theory",
+                            "doc_count": 8851
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time_series",
+                            "doc_count": 7911
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dipole",
+                            "doc_count": 7761
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Higgs_boson",
+                            "doc_count": 7571
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Euclidean_space",
+                            "doc_count": 6888
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Special_unitary_group",
+                            "doc_count": 6719
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_mechanics",
+                            "doc_count": 6640
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sigma",
+                            "doc_count": 6482
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Classical_mechanics",
+                            "doc_count": 6468
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Orbit",
+                            "doc_count": 6293
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Majorana_fermion",
+                            "doc_count": 6101
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Orbital_period",
+                            "doc_count": 6038
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Blood_plasma",
+                            "doc_count": 6017
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Isomorphism",
+                            "doc_count": 5924
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Statistical_dispersion",
+                            "doc_count": 5411
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Complex_network",
+                            "doc_count": 5401
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hubble_Space_Telescope",
+                            "doc_count": 5214
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Angular_momentum_coupling",
+                            "doc_count": 4713
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Equivariant_map",
+                            "doc_count": 4627
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Orbital_inclination",
+                            "doc_count": 4484
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quadrupole",
+                            "doc_count": 4439
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Calabi–Yau_manifold",
+                            "doc_count": 4316
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Compactification_(mathematics)",
+                            "doc_count": 4240
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cell_membrane",
+                            "doc_count": 4142
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hypersurface",
+                            "doc_count": 4104
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Group_action",
+                            "doc_count": 4044
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Surface_brightness",
+                            "doc_count": 4029
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electronic_band_structure",
+                            "doc_count": 4016
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Einstein_field_equations",
+                            "doc_count": 3961
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Renormalization",
+                            "doc_count": 3887
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_field_theory",
+                            "doc_count": 3445
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Higgs_mechanism",
+                            "doc_count": 3444
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dynamical_system",
+                            "doc_count": 3417
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Collinearity",
+                            "doc_count": 3347
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Doppler_effect",
+                            "doc_count": 3248
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/International_dollar",
+                            "doc_count": 3200
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Codimension",
+                            "doc_count": 3186
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thermodynamic_limit",
+                            "doc_count": 3147
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Astrophysical_plasma",
+                            "doc_count": 3125
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Triangle",
+                            "doc_count": 3119
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Self-energy",
+                            "doc_count": 3070
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Artificial_intelligence",
+                            "doc_count": 2974
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Percolation_theory",
+                            "doc_count": 2974
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Direct_current",
+                            "doc_count": 2891
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Aperture",
+                            "doc_count": 2888
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Branching_fraction",
+                            "doc_count": 2877
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Central_processing_unit",
+                            "doc_count": 2844
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Exponential_decay",
+                            "doc_count": 2841
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Stochastic_differential_equation",
+                            "doc_count": 2811
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Angular_resolution",
+                            "doc_count": 2787
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Molecular_dynamics",
+                            "doc_count": 2755
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Classical_physics",
+                            "doc_count": 2721
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectral_energy_distribution",
+                            "doc_count": 2698
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Graph_of_a_function",
+                            "doc_count": 2686
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dissociative",
+                            "doc_count": 2649
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Atomic_orbital",
+                            "doc_count": 2613
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Adsorption",
+                            "doc_count": 2588
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cross-correlation",
+                            "doc_count": 2564
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum",
+                            "doc_count": 2486
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thermalisation",
+                            "doc_count": 2485
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electrode",
+                            "doc_count": 2473
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Symplectic_manifold",
+                            "doc_count": 2454
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Lorentz_group",
+                            "doc_count": 2452
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/ImageNet",
+                            "doc_count": 2423
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ab_initio",
+                            "doc_count": 2412
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_computing",
+                            "doc_count": 2410
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Feature_learning",
+                            "doc_count": 2399
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Full_width_at_half_maximum",
+                            "doc_count": 2359
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Tetragonal_crystal_system",
+                            "doc_count": 2355
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Feynman_diagram",
+                            "doc_count": 2352
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_phase_transition",
+                            "doc_count": 2328
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Bootstrapping",
+                            "doc_count": 2270
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Radial_velocity",
+                            "doc_count": 2255
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Toy_model",
+                            "doc_count": 2241
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Astronomy",
+                            "doc_count": 2235
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Numerical_analysis",
+                            "doc_count": 2217
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ab_initio_quantum_chemistry_methods",
+                            "doc_count": 2072
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Information_theory",
+                            "doc_count": 2072
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Compact_star",
+                            "doc_count": 2056
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scattering_length",
+                            "doc_count": 2001
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Stochastic_gradient_descent",
+                            "doc_count": 2001
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Self-adjoint_operator",
+                            "doc_count": 1978
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Digital_image_processing",
+                            "doc_count": 1972
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Model_selection",
+                            "doc_count": 1969
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Orientability",
+                            "doc_count": 1960
+                        }
+                    ]
+                }
+            },
+            "top_URI_100": {
+                "doc_count": 2195819,
+                "URIs_100": {
+                    "doc_count_error_upper_bound": 1871,
+                    "sum_other_doc_count": 1576924,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Photon",
+                            "doc_count": 29434
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Phase_transition",
+                            "doc_count": 23142
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Superconductivity",
+                            "doc_count": 19199
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ferromagnetism",
+                            "doc_count": 15508
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Deep_learning",
+                            "doc_count": 15288
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Graphene",
+                            "doc_count": 14487
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fermion",
+                            "doc_count": 13496
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Meson",
+                            "doc_count": 13126
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Phase_diagram",
+                            "doc_count": 12831
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Metallicity",
+                            "doc_count": 12222
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electronvolt",
+                            "doc_count": 11645
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Eigenvalues_and_eigenvectors",
+                            "doc_count": 10583
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nucleon",
+                            "doc_count": 10116
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gluon",
+                            "doc_count": 9852
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ionization",
+                            "doc_count": 9697
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Qubit",
+                            "doc_count": 9551
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Supersymmetry",
+                            "doc_count": 9547
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dielectric",
+                            "doc_count": 9084
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Phonon",
+                            "doc_count": 8934
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Brane",
+                            "doc_count": 8891
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Supergravity",
+                            "doc_count": 8891
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Pion",
+                            "doc_count": 8860
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/ArXiv",
+                            "doc_count": 8778
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Renormalization_group",
+                            "doc_count": 8569
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cosmological_constant",
+                            "doc_count": 8437
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Density_functional_theory",
+                            "doc_count": 8388
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hilbert_space",
+                            "doc_count": 8386
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Higgs_boson",
+                            "doc_count": 7485
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Solar_mass",
+                            "doc_count": 7411
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quasiparticle",
+                            "doc_count": 7090
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Light_curve",
+                            "doc_count": 7016
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_decoherence",
+                            "doc_count": 6754
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Chemical_potential",
+                            "doc_count": 6311
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Accretion_disk",
+                            "doc_count": 6061
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cosmic_microwave_background",
+                            "doc_count": 5753
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quasar",
+                            "doc_count": 5686
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Main_sequence",
+                            "doc_count": 5607
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Interstellar_medium",
+                            "doc_count": 5456
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_gravity",
+                            "doc_count": 5410
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Lattice_QCD",
+                            "doc_count": 5238
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fluid_dynamics",
+                            "doc_count": 5139
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/XMM-Newton",
+                            "doc_count": 4987
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/CP_violation",
+                            "doc_count": 4930
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ansatz",
+                            "doc_count": 4922
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Active_galactic_nucleus",
+                            "doc_count": 4902
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Tevatron",
+                            "doc_count": 4821
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Paramagnetism",
+                            "doc_count": 4761
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_field_theory",
+                            "doc_count": 4711
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hubbard_model",
+                            "doc_count": 4701
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Density_matrix",
+                            "doc_count": 4569
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Markov_chain",
+                            "doc_count": 4285
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Zimbabwean_dollar",
+                            "doc_count": 4285
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/White_dwarf",
+                            "doc_count": 4220
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/$O$",
+                            "doc_count": 4212
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/CERN",
+                            "doc_count": 4182
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cosmic_ray",
+                            "doc_count": 4061
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Exciton",
+                            "doc_count": 3997
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Euclidean_space",
+                            "doc_count": 3975
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Optimal_control",
+                            "doc_count": 3975
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Effective_field_theory",
+                            "doc_count": 3749
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spintronics",
+                            "doc_count": 3727
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/MIMO",
+                            "doc_count": 3671
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Attractor",
+                            "doc_count": 3557
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Pair_production",
+                            "doc_count": 3547
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Galaxy_formation_and_evolution",
+                            "doc_count": 3514
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Antiferromagnetism",
+                            "doc_count": 3511
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Statistical_mechanics",
+                            "doc_count": 3447
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Large_Hadron_Collider",
+                            "doc_count": 3394
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Compton_scattering",
+                            "doc_count": 3340
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Planck_units",
+                            "doc_count": 3205
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sloan_Digital_Sky_Survey",
+                            "doc_count": 3191
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Inflaton",
+                            "doc_count": 3188
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Axion",
+                            "doc_count": 3168
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Liquid_crystal",
+                            "doc_count": 3166
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fermilab",
+                            "doc_count": 3114
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Invariant_mass",
+                            "doc_count": 3082
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Random_matrix",
+                            "doc_count": 3045
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Numerical_analysis",
+                            "doc_count": 3044
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Riemannian_manifold",
+                            "doc_count": 3037
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Globular_cluster",
+                            "doc_count": 2990
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scalar_curvature",
+                            "doc_count": 2981
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Vorticity",
+                            "doc_count": 2972
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_Monte_Carlo",
+                            "doc_count": 2944
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Graviton",
+                            "doc_count": 2927
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Stellar_evolution",
+                            "doc_count": 2893
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Supersymmetry_breaking",
+                            "doc_count": 2868
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wilkinson_Microwave_Anisotropy_Probe",
+                            "doc_count": 2852
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thermal_conductivity",
+                            "doc_count": 2828
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Jamaican_dollar",
+                            "doc_count": 2807
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Exoplanet",
+                            "doc_count": 2804
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gravitational_lens",
+                            "doc_count": 2771
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Diffeomorphism",
+                            "doc_count": 2704
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/M-theory",
+                            "doc_count": 2682
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cold_dark_matter",
+                            "doc_count": 2662
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Galactic_Center",
+                            "doc_count": 2650
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Photosphere",
+                            "doc_count": 2631
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gaussian_process",
+                            "doc_count": 2605
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Multi-agent_system",
+                            "doc_count": 2600
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Magnetic_susceptibility",
+                            "doc_count": 2588
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/LHCb_experiment",
+                            "doc_count": 2584
+                        }
+                    ]
+                }
+            },
+            "top_URI_90": {
+                "doc_count": 3801500,
+                "URI": {
+                    "doc_count_error_upper_bound": 4115,
+                    "sum_other_doc_count": 2287468,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_mechanics",
+                            "doc_count": 53950
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Physics",
+                            "doc_count": 52887
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dynamical_system",
+                            "doc_count": 52321
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Classical_mechanics",
+                            "doc_count": 48362
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Magnetic_field",
+                            "doc_count": 46149
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Theorem",
+                            "doc_count": 40802
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Molecular_dynamics",
+                            "doc_count": 38819
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quark",
+                            "doc_count": 32465
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Entropy",
+                            "doc_count": 28214
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_chromodynamics",
+                            "doc_count": 28011
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_field_theory",
+                            "doc_count": 27686
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Monte_Carlo_method",
+                            "doc_count": 26979
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hamiltonian_mechanics",
+                            "doc_count": 25848
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Redshift",
+                            "doc_count": 23455
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Neutrino",
+                            "doc_count": 23154
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dark_matter",
+                            "doc_count": 22867
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Black_hole",
+                            "doc_count": 22463
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Factorial",
+                            "doc_count": 22225
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Fermion",
+                            "doc_count": 20182
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Large_Hadron_Collider",
+                            "doc_count": 19442
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spacetime",
+                            "doc_count": 19337
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electronvolt",
+                            "doc_count": 19217
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Tensor",
+                            "doc_count": 18651
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Manifold",
+                            "doc_count": 18450
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Laser",
+                            "doc_count": 17917
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Machine_learning",
+                            "doc_count": 17866
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectroscopy",
+                            "doc_count": 17285
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Polynomial",
+                            "doc_count": 17095
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Neutron",
+                            "doc_count": 16295
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Resonance",
+                            "doc_count": 16195
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Standard_Model",
+                            "doc_count": 15972
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Anisotropy",
+                            "doc_count": 15426
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/X-ray",
+                            "doc_count": 15273
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_computing",
+                            "doc_count": 14930
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/String_theory",
+                            "doc_count": 14219
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Proton",
+                            "doc_count": 13656
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gamma_ray",
+                            "doc_count": 13647
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ion",
+                            "doc_count": 13534
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Infrared",
+                            "doc_count": 13217
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Angular_momentum",
+                            "doc_count": 12896
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dirac_equation",
+                            "doc_count": 12751
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hydrogen",
+                            "doc_count": 12620
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Telescope",
+                            "doc_count": 12181
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Atom",
+                            "doc_count": 12025
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gauge_theory",
+                            "doc_count": 11966
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Malaysian_ringgit",
+                            "doc_count": 11748
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Australian_dollar",
+                            "doc_count": 11712
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scalar_field",
+                            "doc_count": 11309
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/X-ray_astronomy",
+                            "doc_count": 11280
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum",
+                            "doc_count": 11130
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electric_field",
+                            "doc_count": 10986
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Classical_physics",
+                            "doc_count": 10824
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Albert_Einstein",
+                            "doc_count": 10713
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Brazilian_real",
+                            "doc_count": 10286
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Markov_chain",
+                            "doc_count": 10254
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Physical_cosmology",
+                            "doc_count": 10249
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Perturbation_theory",
+                            "doc_count": 10239
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wave_function",
+                            "doc_count": 10192
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Phase_space",
+                            "doc_count": 10153
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Power_law",
+                            "doc_count": 9876
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Singapore_dollar",
+                            "doc_count": 9468
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Lepton",
+                            "doc_count": 9441
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cohomology",
+                            "doc_count": 9211
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Microwave",
+                            "doc_count": 8931
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Carbon",
+                            "doc_count": 8868
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Viscosity",
+                            "doc_count": 8867
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Kinematics",
+                            "doc_count": 8858
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time_complexity",
+                            "doc_count": 8836
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Supernova",
+                            "doc_count": 8742
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Torus",
+                            "doc_count": 8725
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cloud",
+                            "doc_count": 8699
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Bayesian_inference",
+                            "doc_count": 8565
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Milky_Way",
+                            "doc_count": 8546
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Neutron_star",
+                            "doc_count": 8440
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sun",
+                            "doc_count": 8260
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dark_energy",
+                            "doc_count": 8142
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Semiconductor",
+                            "doc_count": 8018
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Renormalization",
+                            "doc_count": 7987
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Integral_transform",
+                            "doc_count": 7952
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Lagrangian_mechanics",
+                            "doc_count": 7863
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/General_relativity",
+                            "doc_count": 7697
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Muon",
+                            "doc_count": 7578
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Lie_algebra",
+                            "doc_count": 7575
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electroweak_interaction",
+                            "doc_count": 7508
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Canadian_dollar",
+                            "doc_count": 7338
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Reinforcement_learning",
+                            "doc_count": 7301
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Laplace_operator",
+                            "doc_count": 7241
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Lie_group",
+                            "doc_count": 7139
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_tunnelling",
+                            "doc_count": 7134
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Convolutional_neural_network",
+                            "doc_count": 7114
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Astronomical_spectroscopy",
+                            "doc_count": 7062
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Qi",
+                            "doc_count": 7061
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Interaction",
+                            "doc_count": 7028
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Artificial_neural_network",
+                            "doc_count": 6831
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Pulsar",
+                            "doc_count": 6813
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Iron",
+                            "doc_count": 6747
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Erg",
+                            "doc_count": 6723
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Soliton",
+                            "doc_count": 6668
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Superfluidity",
+                            "doc_count": 6668
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Moduli_space",
+                            "doc_count": 6534
+                        }
+                    ]
+                }
+            },
+            "top_URI_60": {
+                "doc_count": 1979113,
+                "URI": {
+                    "doc_count_error_upper_bound": 2045,
+                    "sum_other_doc_count": 1165902,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Scattering",
+                            "doc_count": 48543
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gravity",
+                            "doc_count": 31660
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Euclidean_vector",
+                            "doc_count": 27221
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electromagnetic_radiation",
+                            "doc_count": 26454
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Three-dimensional_space",
+                            "doc_count": 24396
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scalar_field",
+                            "doc_count": 24067
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Equatorial_Guinea",
+                            "doc_count": 20491
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sun",
+                            "doc_count": 16755
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Special_relativity",
+                            "doc_count": 15047
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Apparent_magnitude",
+                            "doc_count": 14816
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Superconductivity",
+                            "doc_count": 13939
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Magnetization",
+                            "doc_count": 13832
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Accretion_disk",
+                            "doc_count": 13233
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/General_relativity",
+                            "doc_count": 13114
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_vacuum_state",
+                            "doc_count": 13056
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Metric_tensor",
+                            "doc_count": 12787
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Combinatorics",
+                            "doc_count": 12522
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Remarkable_(tablet)",
+                            "doc_count": 12392
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Convergent_series",
+                            "doc_count": 11144
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Riemannian_manifold",
+                            "doc_count": 11044
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/SARS-CoV-2_Delta_variant",
+                            "doc_count": 10947
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Turbulence",
+                            "doc_count": 10131
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Database",
+                            "doc_count": 9360
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Curvature",
+                            "doc_count": 9355
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Metric_space",
+                            "doc_count": 9317
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Rate_of_convergence",
+                            "doc_count": 8860
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Partition_of_a_set",
+                            "doc_count": 8637
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Collider",
+                            "doc_count": 8352
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Subgroup",
+                            "doc_count": 7946
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Non-perturbative",
+                            "doc_count": 7731
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Parsec",
+                            "doc_count": 7717
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Irreducible_representation",
+                            "doc_count": 7711
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gauge_theory",
+                            "doc_count": 7704
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Regression_analysis",
+                            "doc_count": 7650
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Limit_of_a_sequence",
+                            "doc_count": 7131
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electrical_resistivity_and_conductivity",
+                            "doc_count": 7127
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Statistical_classification",
+                            "doc_count": 6945
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Thin_film",
+                            "doc_count": 6849
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectral_line",
+                            "doc_count": 6702
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Galaxy_morphological_classification",
+                            "doc_count": 6640
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Convex_function",
+                            "doc_count": 6472
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electromagnetism",
+                            "doc_count": 5979
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/James_Clerk_Maxwell",
+                            "doc_count": 5932
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Convergence_of_random_variables",
+                            "doc_count": 5929
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dynamical_system",
+                            "doc_count": 5867
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Bipartite_graph",
+                            "doc_count": 5856
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Vacuum",
+                            "doc_count": 5820
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Wave_function",
+                            "doc_count": 5808
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Discretization",
+                            "doc_count": 5801
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scalability",
+                            "doc_count": 5708
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Inflation",
+                            "doc_count": 5706
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hertz",
+                            "doc_count": 5655
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Parton_(particle_physics)",
+                            "doc_count": 5520
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Damping",
+                            "doc_count": 5465
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/River_delta",
+                            "doc_count": 5414
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Matrix_norm",
+                            "doc_count": 5405
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cosmic_microwave_background",
+                            "doc_count": 5364
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/The_Algorithm",
+                            "doc_count": 5340
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Poisson_distribution",
+                            "doc_count": 5286
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Minute_and_second_of_arc",
+                            "doc_count": 5169
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Interpolation",
+                            "doc_count": 5069
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dopant",
+                            "doc_count": 5057
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Monolayer",
+                            "doc_count": 5040
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Propagator",
+                            "doc_count": 4834
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Scalar_field_theory",
+                            "doc_count": 4711
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Triplet_state",
+                            "doc_count": 4633
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/On_shell_and_off_shell",
+                            "doc_count": 4605
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Incompressible_flow",
+                            "doc_count": 4559
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Exoplanet",
+                            "doc_count": 4505
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Inflationary_epoch",
+                            "doc_count": 4501
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nanoscopic_scale",
+                            "doc_count": 4315
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Isomorphism",
+                            "doc_count": 4294
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Area_density",
+                            "doc_count": 4256
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Relic",
+                            "doc_count": 4149
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/2",
+                            "doc_count": 4129
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_mechanics",
+                            "doc_count": 4121
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ejecta",
+                            "doc_count": 4014
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Radiation",
+                            "doc_count": 4013
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Compact_Muon_Solenoid",
+                            "doc_count": 3978
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Tight_binding",
+                            "doc_count": 3974
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Self-similarity",
+                            "doc_count": 3964
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Neutrino",
+                            "doc_count": 3917
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Convex_set",
+                            "doc_count": 3903
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Cosmic_ray",
+                            "doc_count": 3844
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Broadband",
+                            "doc_count": 3817
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Convex_optimization",
+                            "doc_count": 3698
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Sobolev_space",
+                            "doc_count": 3698
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/ATLAS_experiment",
+                            "doc_count": 3645
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Chern–Simons_theory",
+                            "doc_count": 3614
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nuclear_matter",
+                            "doc_count": 3582
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Partial_differential_equation",
+                            "doc_count": 3545
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Superposition_principle",
+                            "doc_count": 3524
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Torsion_tensor",
+                            "doc_count": 3507
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Deep_learning",
+                            "doc_count": 3469
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Modular_arithmetic",
+                            "doc_count": 3455
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Square_lattice",
+                            "doc_count": 3410
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Effective_field_theory",
+                            "doc_count": 3379
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Crystal_structure",
+                            "doc_count": 3310
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Magnetism",
+                            "doc_count": 3202
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Kinematics",
+                            "doc_count": 3150
+                        }
+                    ]
+                }
+            },
+            "top_URI_70": {
+                "doc_count": 1502562,
+                "URI": {
+                    "doc_count_error_upper_bound": 1389,
+                    "sum_other_doc_count": 797839,
+                    "buckets": [
+                        {
+                            "key": "http://dbpedia.org/resource/Definite_matrix",
+                            "doc_count": 46597
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electronvolt",
+                            "doc_count": 37841
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mathematical_optimization",
+                            "doc_count": 32011
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Crystal_structure",
+                            "doc_count": 27735
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Luminosity",
+                            "doc_count": 27619
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Diffusion",
+                            "doc_count": 20095
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Integer",
+                            "doc_count": 18999
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Bravais_lattice",
+                            "doc_count": 18644
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Euclidean_vector",
+                            "doc_count": 17761
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Isotropy",
+                            "doc_count": 17148
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Normal_distribution",
+                            "doc_count": 15340
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Anisotropy",
+                            "doc_count": 14521
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Photometry_(astronomy)",
+                            "doc_count": 14107
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Interplay_Entertainment",
+                            "doc_count": 13764
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Variance",
+                            "doc_count": 12458
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Vector_space",
+                            "doc_count": 11960
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Special_unitary_group",
+                            "doc_count": 11303
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Circle_group",
+                            "doc_count": 10773
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Regularization_(mathematics)",
+                            "doc_count": 10554
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Correlation_function",
+                            "doc_count": 9683
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Earth",
+                            "doc_count": 9488
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dopant",
+                            "doc_count": 9358
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Voltage",
+                            "doc_count": 8979
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Tongan_paʻanga",
+                            "doc_count": 8201
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spectral_density",
+                            "doc_count": 7794
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Shear_stress",
+                            "doc_count": 7763
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Orthogonality",
+                            "doc_count": 7461
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Oxygen",
+                            "doc_count": 6869
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hyperbolic_geometry",
+                            "doc_count": 6814
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Infrared",
+                            "doc_count": 6716
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Vortex",
+                            "doc_count": 6510
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Critical_phenomena",
+                            "doc_count": 6263
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_electrodynamics",
+                            "doc_count": 5472
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Metastability",
+                            "doc_count": 5315
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Partition_function_(statistical_mechanics)",
+                            "doc_count": 5224
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Arithmetic_genus",
+                            "doc_count": 5129
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mirror",
+                            "doc_count": 5049
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Pixel",
+                            "doc_count": 5021
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ethiopian_birr",
+                            "doc_count": 4910
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Rotation_matrix",
+                            "doc_count": 4720
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mesoscopic_physics",
+                            "doc_count": 4656
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Probability_distribution",
+                            "doc_count": 4634
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_mechanics",
+                            "doc_count": 4440
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Energy_density",
+                            "doc_count": 4419
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Velocity_dispersion",
+                            "doc_count": 4378
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Signal-to-noise_ratio",
+                            "doc_count": 4358
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gravitational_wave",
+                            "doc_count": 4344
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Classical_mechanics",
+                            "doc_count": 4162
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Algebra_over_a_field",
+                            "doc_count": 3980
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Torque",
+                            "doc_count": 3861
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Boundary_value_problem",
+                            "doc_count": 3815
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gallium_arsenide",
+                            "doc_count": 3807
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Lattice_graph",
+                            "doc_count": 3736
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Vector_field",
+                            "doc_count": 3714
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Commutative_property",
+                            "doc_count": 3703
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gaussian_function",
+                            "doc_count": 3575
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gaussian_process",
+                            "doc_count": 3329
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nonparametric_statistics",
+                            "doc_count": 3301
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Number_density",
+                            "doc_count": 3246
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Active_galactic_nucleus",
+                            "doc_count": 3236
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/General_relativity",
+                            "doc_count": 3233
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Infinitesimal",
+                            "doc_count": 3131
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Seyfert_galaxy",
+                            "doc_count": 3123
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Renormalization_group",
+                            "doc_count": 3080
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hyperfine_structure",
+                            "doc_count": 3062
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Effective_mass_(solid-state_physics)",
+                            "doc_count": 3033
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Independent_and_identically_distributed_random_variables",
+                            "doc_count": 2986
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Hyperbolic_partial_differential_equation",
+                            "doc_count": 2971
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Protein_dimer",
+                            "doc_count": 2804
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Bilinear_form",
+                            "doc_count": 2796
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Gravitational_field",
+                            "doc_count": 2794
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Electronic_Frontier_Foundation",
+                            "doc_count": 2784
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Time_complexity",
+                            "doc_count": 2758
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Atacama_Large_Millimeter_Array",
+                            "doc_count": 2694
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Mathematical_model",
+                            "doc_count": 2667
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/BCS_theory",
+                            "doc_count": 2649
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Object_detection",
+                            "doc_count": 2613
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Modular_arithmetic",
+                            "doc_count": 2596
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quiver",
+                            "doc_count": 2582
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Doublet_state",
+                            "doc_count": 2569
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Charge-coupled_device",
+                            "doc_count": 2539
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_entanglement",
+                            "doc_count": 2523
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Ground_truth",
+                            "doc_count": 2518
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Type_II_string_theory",
+                            "doc_count": 2512
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Vacuum_energy",
+                            "doc_count": 2477
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Magnetohydrodynamics",
+                            "doc_count": 2456
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Linear_combination",
+                            "doc_count": 2450
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Glossary_of_graph_theory",
+                            "doc_count": 2438
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Nuclear_magnetic_resonance",
+                            "doc_count": 2403
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Abrikosov_vortex",
+                            "doc_count": 2369
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Quantum_field_theory",
+                            "doc_count": 2347
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Spin_polarization",
+                            "doc_count": 2342
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Observable_universe",
+                            "doc_count": 2318
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Configuration_space_(physics)",
+                            "doc_count": 2299
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Dynamical_system",
+                            "doc_count": 2253
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Classical_physics",
+                            "doc_count": 2242
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Group_action",
+                            "doc_count": 2208
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Axial_chirality",
+                            "doc_count": 2182
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Elastic_scattering",
+                            "doc_count": 2131
+                        },
+                        {
+                            "key": "http://dbpedia.org/resource/Parton_(particle_physics)",
+                            "doc_count": 2128
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Finds the most frequent URI terms across all dbpedia entities when first
filtered on confidence.

See README.md for more detail.

closes #59