### PR TITLE
Fix duplicate counting bug

### DIFF
--- a/arxlive_spotlight_annotation/src/node_modules/dbpedia/spotlight.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/dbpedia/spotlight.mjs
@@ -264,8 +264,8 @@ export const generateMetaData = (reducedTerms, spotlightResults) => {
 			confidence_avg: prev.confidence_avg + curr.confidence,
 			confidence_max: curr.confidence > prev.confidence_max ? curr.confidence : prev.confidence_max,
 			confidence_min: curr.confidence < prev.confidence_min ? curr.confidence : prev.confidence_min,
-			dupes_10_count: prev.dupes_10_count + curr.duplicates_10 > 1 ? 1 : 0,
-			dupes_60_count: prev.dupes_60_count + curr.duplicates_60 > 1 ? 1 : 0,
+			dupes_10_count: prev.dupes_10_count + (curr.duplicates_10 > 1 ? 1 : 0),
+			dupes_60_count: prev.dupes_60_count + (curr.duplicates_60 > 1 ? 1 : 0),
 			confidence_counts: {
 				...prev.confidence_counts,
 				[curr.confidence]: prev.confidence_counts[curr.confidence]


### PR DESCRIPTION
PR to fix the counting bug. Order of precedence meant the ternary
operator was being calculated incorrectly, so we only ever had values
of zero or one for the number of duplicates per dbpedia_entity.

closes #62