### PR TITLE
Use bulk update API

### DIFF
--- a/arxlive_spotlight_annotation/package.json
+++ b/arxlive_spotlight_annotation/package.json
@@ -32,7 +32,7 @@
 	},
 	"scripts": {
 		"annotate": "cross-env NODE_ENV=production NODE_NO_WARNINGS=1 node src/bin/es/annotate.mjs --field textBody_abstract_article --name dbpedia_entities --index arxiv_v6 --spotlight http://localhost:2222/rest/annotate --page-size 100 --include-metadata",
-		"rebuildTestIndex": "node src/bin/es/index.mjs delete test && sleep 1 && node src/bin/es/index.mjs create test --path src/test/conf/test_index_mapping.json && sleep 1 && node src/bin/es/index.mjs reindex arxiv_v6 test --ignore dbpedia_entities --max-docs 1000",
+		"rebuildTestIndex": "node src/bin/es/index.mjs delete test && sleep 1 && node src/bin/es/index.mjs create test --path src/test/conf/test_index_mapping.json && sleep 1 && node src/bin/es/index.mjs reindex arxiv_v6 test --ignore dbpedia_entities dbpedia_entities_metadata --max-docs 1000",
 		"rebuildEdgeCasesIndex": "node src/bin/es/index.mjs delete edge-cases && sleep 1 && node src/bin/es/index.mjs create edge-cases && sleep 1 && node src/bin/es/document.mjs create edge-cases ./src/test/data/elastic_search_results/test_documents.json",
 		"rebuild": "npm run rebuildTestIndex && npm run rebuildEdgeCasesIndex",
 		"testAnnotationRemotely": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --index test --spotlight http://localhost:2222/rest/annotate --page-size 10",

--- a/arxlive_spotlight_annotation/src/node_modules/es/requests.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/requests.mjs
@@ -27,7 +27,7 @@ export const buildRequest = (
 	domain,
 	path,
 	method,
-	{ payload, query = {} } = {}
+	{ payload, contentType = 'application/json', query = {} } = {}
 ) => {
 	const body =
 		payload && typeof payload !== 'string'
@@ -39,7 +39,7 @@ export const buildRequest = (
 		path,
 		query,
 		headers: {
-			'Content-Type': 'application/json',
+			'Content-Type': contentType,
 			host: domain,
 		},
 		hostname: domain,

--- a/arxlive_spotlight_annotation/src/node_modules/es/update.mjs
+++ b/arxlive_spotlight_annotation/src/node_modules/es/update.mjs
@@ -1,3 +1,4 @@
+import * as _ from 'lamb'
 import { stringify } from '@svizzle/utils';
 import { buildRequest, makeRequest } from 'es/requests.mjs';
 
@@ -16,7 +17,6 @@ export const update = async (domain, index, id, doc, options = {}) => {
 	const request = buildRequest(domain, path, 'POST', { payload });
 	const { body: response, code } = await makeRequest(request, options);
 	if (code != 200) {
-		console.log(response);
 		throw Error(
 			`Update failed at ${domain}/${index} for document with ID: ${id}. 
 			Response:\n${stringify(response)}`
@@ -24,3 +24,35 @@ export const update = async (domain, index, id, doc, options = {}) => {
 	}
 	return response;
 };
+
+const generateBulkUpdatePayload = index => _.pipe([
+	_.flatMapWith(doc =>
+		[
+			{ update: { "_id": doc.id, "_index": index } },
+			{ doc: doc.data }
+		]
+	),
+	_.reduceWith((acc, curr) => `${acc}\n${JSON.stringify(curr)}`, ''),
+	json => `${json}\n`
+])
+
+/**
+ * @function bulkUpdate
+ * @description updates multiple documents on an ES index in one request.
+ * @param {string} domain - domain on which to update.
+ * @param {string} index - index on which to update.
+ * @param {Object[]} documents - list of documents, where each object has an id 
+ * key and a data key. The data key is the partial document used for updating.
+ * @returns {HttpResponse} response of the update reqeuest.
+ */
+export const bulkUpdate = async (domain, index, documents, options = {}) => {
+	const path = `${index}/_bulk`
+	const generateForIndex = generateBulkUpdatePayload(index)
+	const payload = generateForIndex(documents)
+	const request = buildRequest(domain, path, 'POST', { payload, contentType: 'application/x-ndjson' });
+	const { body: response, code } = await makeRequest(request, options);
+	if (code != 200) {
+		throw new Error(`Bulk update failed with response\n${stringify(response)}`)
+	}
+	return response;
+}


### PR DESCRIPTION
The annotation process now uses the bulk update API when sending
updates to the domain and index. This will potentially greatly improve
annotation speeds, as it helps tackle the current I/0 bottleneck.

closes #64