### PR TITLE
Duplicate aggregations

### DIFF
--- a/arxlive_spotlight_annotation/dataQuality/aggs/duplicateAggregations/README.md
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/duplicateAggregations/README.md
@@ -1,0 +1,24 @@
+## Duplicate Aggregations
+
+These aggregations include a mixture of different descriptive statistics
+relating to metadata which describes the duplicates found for entities provided
+by the Spotlight Tool. In particular, `dupes_10` and `dupes_60` are measures of
+how many duplicates were found **at that confidence level**. So if
+`dupes_10_count`'s value is 6, then there were a total of 6 duplicates found at
+confidence level 10. One entity having duplicates counts as a single occurrence
+of a duplicate, e.g. if `Photon` has 3 duplicates found at confidence level 10,
+it will contribute 1 occurrence to the total `dupes_10_count`.
+
+We also provide aggregations on the `dupes_ratio_X` metadata value, which is
+simply the `dupes_count_X` value divided by the total number of entities
+annotated for that piece of text.
+
+The aggregations use both `extended_stats` and `histogram`s for each metadata
+value (`dupes_count_X` and `dupes_ratio_X`)
+
+Endpoint: `POST arxiv_v6/_search`
+
+See:
+
+- https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-aggregations-bucket-histogram-aggregation.html
+- https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-aggregations-metrics-extendedstats-aggregation.html

--- a/arxlive_spotlight_annotation/dataQuality/aggs/duplicateAggregations/request.json
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/duplicateAggregations/request.json
@@ -1,0 +1,53 @@
+{
+    "size": 0,
+    "aggs": {
+        "dupes_10_count_extended_stats": {
+            "extended_stats": {
+                "field": "dbpedia_entities_metadata.dupes_10_count"
+            }
+        },
+        "dupes_10_count_histogram": {
+            "histogram": {
+                "field": "dbpedia_entities_metadata.dupes_10_count",
+                "interval": 1,
+                "min_doc_count": 1
+            }
+        },
+        "dupes_10_ratio_extended_stats": {
+            "extended_stats": {
+                "field": "dbpedia_entities_metadata.dupes_10_ratio"
+            }
+        },
+        "dupes_10_ratio_histogram": {
+            "histogram": {
+                "field": "dbpedia_entities_metadata.dupes_10_ratio",
+                "interval": 0.01,
+                "min_doc_count": 1
+            }
+        },
+        "dupes_60_count_extended_stats": {
+            "extended_stats": {
+                "field": "dbpedia_entities_metadata.dupes_60_count"
+            }
+        },
+        "dupes_60_count_histogram": {
+            "histogram": {
+                "field": "dbpedia_entities_metadata.dupes_60_count",
+                "interval": 1,
+                "min_doc_count": 1
+            }
+        },
+        "dupes_60_ratio_extended_stats": {
+            "extended_stats": {
+                "field": "dbpedia_entities_metadata.dupes_60_ratio"
+            }
+        },
+        "dupes_60_ratio_histogram": {
+            "histogram": {
+                "field": "dbpedia_entities_metadata.dupes_60_ratio",
+                "interval": 0.01,
+                "min_doc_count": 1
+            }
+        }
+    }
+}

--- a/arxlive_spotlight_annotation/dataQuality/aggs/duplicateAggregations/response.json
+++ b/arxlive_spotlight_annotation/dataQuality/aggs/duplicateAggregations/response.json
@@ -1,0 +1,928 @@
+{
+    "took": 557,
+    "timed_out": false,
+    "_shards": {
+        "total": 5,
+        "successful": 5,
+        "skipped": 0,
+        "failed": 0
+    },
+    "hits": {
+        "total": {
+            "value": 10000,
+            "relation": "gte"
+        },
+        "max_score": null,
+        "hits": []
+    },
+    "aggregations": {
+        "dupes_60_count_histogram": {
+            "buckets": [
+                {
+                    "key": 0.0,
+                    "doc_count": 559093
+                },
+                {
+                    "key": 1.0,
+                    "doc_count": 546943
+                },
+                {
+                    "key": 2.0,
+                    "doc_count": 373153
+                },
+                {
+                    "key": 3.0,
+                    "doc_count": 206066
+                },
+                {
+                    "key": 4.0,
+                    "doc_count": 98257
+                },
+                {
+                    "key": 5.0,
+                    "doc_count": 42271
+                },
+                {
+                    "key": 6.0,
+                    "doc_count": 16528
+                },
+                {
+                    "key": 7.0,
+                    "doc_count": 5896
+                },
+                {
+                    "key": 8.0,
+                    "doc_count": 1913
+                },
+                {
+                    "key": 9.0,
+                    "doc_count": 642
+                },
+                {
+                    "key": 10.0,
+                    "doc_count": 182
+                },
+                {
+                    "key": 11.0,
+                    "doc_count": 53
+                },
+                {
+                    "key": 12.0,
+                    "doc_count": 14
+                },
+                {
+                    "key": 13.0,
+                    "doc_count": 6
+                },
+                {
+                    "key": 14.0,
+                    "doc_count": 4
+                }
+            ]
+        },
+        "dupes_10_count_histogram": {
+            "buckets": [
+                {
+                    "key": 0.0,
+                    "doc_count": 63585
+                },
+                {
+                    "key": 1.0,
+                    "doc_count": 72175
+                },
+                {
+                    "key": 2.0,
+                    "doc_count": 92733
+                },
+                {
+                    "key": 3.0,
+                    "doc_count": 112800
+                },
+                {
+                    "key": 4.0,
+                    "doc_count": 128942
+                },
+                {
+                    "key": 5.0,
+                    "doc_count": 137108
+                },
+                {
+                    "key": 6.0,
+                    "doc_count": 140310
+                },
+                {
+                    "key": 7.0,
+                    "doc_count": 138205
+                },
+                {
+                    "key": 8.0,
+                    "doc_count": 131953
+                },
+                {
+                    "key": 9.0,
+                    "doc_count": 122011
+                },
+                {
+                    "key": 10.0,
+                    "doc_count": 110721
+                },
+                {
+                    "key": 11.0,
+                    "doc_count": 99570
+                },
+                {
+                    "key": 12.0,
+                    "doc_count": 87358
+                },
+                {
+                    "key": 13.0,
+                    "doc_count": 76028
+                },
+                {
+                    "key": 14.0,
+                    "doc_count": 65211
+                },
+                {
+                    "key": 15.0,
+                    "doc_count": 55749
+                },
+                {
+                    "key": 16.0,
+                    "doc_count": 47081
+                },
+                {
+                    "key": 17.0,
+                    "doc_count": 38851
+                },
+                {
+                    "key": 18.0,
+                    "doc_count": 32526
+                },
+                {
+                    "key": 19.0,
+                    "doc_count": 26293
+                },
+                {
+                    "key": 20.0,
+                    "doc_count": 20542
+                },
+                {
+                    "key": 21.0,
+                    "doc_count": 15864
+                },
+                {
+                    "key": 22.0,
+                    "doc_count": 11521
+                },
+                {
+                    "key": 23.0,
+                    "doc_count": 8381
+                },
+                {
+                    "key": 24.0,
+                    "doc_count": 5725
+                },
+                {
+                    "key": 25.0,
+                    "doc_count": 3836
+                },
+                {
+                    "key": 26.0,
+                    "doc_count": 2367
+                },
+                {
+                    "key": 27.0,
+                    "doc_count": 1529
+                },
+                {
+                    "key": 28.0,
+                    "doc_count": 897
+                },
+                {
+                    "key": 29.0,
+                    "doc_count": 479
+                },
+                {
+                    "key": 30.0,
+                    "doc_count": 292
+                },
+                {
+                    "key": 31.0,
+                    "doc_count": 160
+                },
+                {
+                    "key": 32.0,
+                    "doc_count": 79
+                },
+                {
+                    "key": 33.0,
+                    "doc_count": 43
+                },
+                {
+                    "key": 34.0,
+                    "doc_count": 19
+                },
+                {
+                    "key": 35.0,
+                    "doc_count": 14
+                },
+                {
+                    "key": 36.0,
+                    "doc_count": 14
+                },
+                {
+                    "key": 37.0,
+                    "doc_count": 13
+                },
+                {
+                    "key": 38.0,
+                    "doc_count": 5
+                },
+                {
+                    "key": 39.0,
+                    "doc_count": 3
+                },
+                {
+                    "key": 40.0,
+                    "doc_count": 4
+                },
+                {
+                    "key": 41.0,
+                    "doc_count": 5
+                },
+                {
+                    "key": 42.0,
+                    "doc_count": 3
+                },
+                {
+                    "key": 43.0,
+                    "doc_count": 3
+                },
+                {
+                    "key": 44.0,
+                    "doc_count": 2
+                },
+                {
+                    "key": 45.0,
+                    "doc_count": 3
+                },
+                {
+                    "key": 46.0,
+                    "doc_count": 3
+                },
+                {
+                    "key": 49.0,
+                    "doc_count": 2
+                },
+                {
+                    "key": 56.0,
+                    "doc_count": 1
+                },
+                {
+                    "key": 57.0,
+                    "doc_count": 1
+                },
+                {
+                    "key": 64.0,
+                    "doc_count": 1
+                }
+            ]
+        },
+        "dupes_60_ratio_extended_stats": {
+            "count": 1851021,
+            "min": 0.0,
+            "max": 0.6666666865348816,
+            "avg": 0.03602303723649162,
+            "sum": 66679.39840852795,
+            "sum_of_squares": 4683.07526934764,
+            "variance": 0.0012323365416007587,
+            "std_deviation": 0.03510465128157177,
+            "std_deviation_bounds": {
+                "upper": 0.10623233979963517,
+                "lower": -0.03418626532665193
+            }
+        },
+        "dupes_60_ratio_histogram": {
+            "buckets": [
+                {
+                    "key": 0.0,
+                    "doc_count": 559139
+                },
+                {
+                    "key": 0.01,
+                    "doc_count": 120346
+                },
+                {
+                    "key": 0.02,
+                    "doc_count": 225184
+                },
+                {
+                    "key": 0.03,
+                    "doc_count": 230357
+                },
+                {
+                    "key": 0.04,
+                    "doc_count": 160711
+                },
+                {
+                    "key": 0.05,
+                    "doc_count": 161803
+                },
+                {
+                    "key": 0.06,
+                    "doc_count": 112078
+                },
+                {
+                    "key": 0.07,
+                    "doc_count": 87106
+                },
+                {
+                    "key": 0.08,
+                    "doc_count": 53162
+                },
+                {
+                    "key": 0.09,
+                    "doc_count": 39217
+                },
+                {
+                    "key": 0.1,
+                    "doc_count": 33685
+                },
+                {
+                    "key": 0.11,
+                    "doc_count": 23461
+                },
+                {
+                    "key": 0.12,
+                    "doc_count": 12140
+                },
+                {
+                    "key": 0.13,
+                    "doc_count": 9801
+                },
+                {
+                    "key": 0.14,
+                    "doc_count": 6402
+                },
+                {
+                    "key": 0.15,
+                    "doc_count": 5441
+                },
+                {
+                    "key": 0.16,
+                    "doc_count": 3080
+                },
+                {
+                    "key": 0.17,
+                    "doc_count": 1901
+                },
+                {
+                    "key": 0.18,
+                    "doc_count": 1652
+                },
+                {
+                    "key": 0.19,
+                    "doc_count": 596
+                },
+                {
+                    "key": 0.2,
+                    "doc_count": 1351
+                },
+                {
+                    "key": 0.21,
+                    "doc_count": 595
+                },
+                {
+                    "key": 0.22,
+                    "doc_count": 474
+                },
+                {
+                    "key": 0.23,
+                    "doc_count": 391
+                },
+                {
+                    "key": 0.24,
+                    "doc_count": 18
+                },
+                {
+                    "key": 0.25,
+                    "doc_count": 371
+                },
+                {
+                    "key": 0.26,
+                    "doc_count": 107
+                },
+                {
+                    "key": 0.27,
+                    "doc_count": 109
+                },
+                {
+                    "key": 0.28,
+                    "doc_count": 83
+                },
+                {
+                    "key": 0.29,
+                    "doc_count": 28
+                },
+                {
+                    "key": 0.3,
+                    "doc_count": 68
+                },
+                {
+                    "key": 0.31,
+                    "doc_count": 25
+                },
+                {
+                    "key": 0.32,
+                    "doc_count": 1
+                },
+                {
+                    "key": 0.33,
+                    "doc_count": 78
+                },
+                {
+                    "key": 0.34,
+                    "doc_count": 4
+                },
+                {
+                    "key": 0.35000000000000003,
+                    "doc_count": 10
+                },
+                {
+                    "key": 0.36,
+                    "doc_count": 9
+                },
+                {
+                    "key": 0.37,
+                    "doc_count": 15
+                },
+                {
+                    "key": 0.38,
+                    "doc_count": 2
+                },
+                {
+                    "key": 0.4,
+                    "doc_count": 6
+                },
+                {
+                    "key": 0.42,
+                    "doc_count": 3
+                },
+                {
+                    "key": 0.5,
+                    "doc_count": 10
+                },
+                {
+                    "key": 0.66,
+                    "doc_count": 1
+                }
+            ]
+        },
+        "dupes_10_ratio_extended_stats": {
+            "count": 1851021,
+            "min": 0.0,
+            "max": 1.0,
+            "avg": 0.20618209264457468,
+            "sum": 381647.38330905326,
+            "sum_of_squares": 94938.05049428123,
+            "variance": 0.008778503513085211,
+            "std_deviation": 0.0936936684791732,
+            "std_deviation_bounds": {
+                "upper": 0.3935694296029211,
+                "lower": 0.018794755686228293
+            }
+        },
+        "dupes_10_count_extended_stats": {
+            "count": 1851021,
+            "min": 0.0,
+            "max": 64.0,
+            "avg": 8.554298411525314,
+            "sum": 1.5834186E7,
+            "sum_of_squares": 1.89711074E8,
+            "variance": 29.313941793422988,
+            "std_deviation": 5.414235106958599,
+            "std_deviation_bounds": {
+                "upper": 19.382768625442512,
+                "lower": -2.2741718023918835
+            }
+        },
+        "dupes_60_count_extended_stats": {
+            "count": 1851021,
+            "min": 0.0,
+            "max": 14.0,
+            "avg": 1.447880386013989,
+            "sum": 2680057.0,
+            "sum_of_squares": 7609809.0,
+            "variance": 2.0147837524806613,
+            "std_deviation": 1.4194307846741459,
+            "std_deviation_bounds": {
+                "upper": 4.286741955362281,
+                "lower": -1.3909811833343027
+            }
+        },
+        "dupes_10_ratio_histogram": {
+            "buckets": [
+                {
+                    "key": 0.0,
+                    "doc_count": 63585
+                },
+                {
+                    "key": 0.01,
+                    "doc_count": 47
+                },
+                {
+                    "key": 0.02,
+                    "doc_count": 2218
+                },
+                {
+                    "key": 0.03,
+                    "doc_count": 10646
+                },
+                {
+                    "key": 0.04,
+                    "doc_count": 12375
+                },
+                {
+                    "key": 0.05,
+                    "doc_count": 21769
+                },
+                {
+                    "key": 0.06,
+                    "doc_count": 21475
+                },
+                {
+                    "key": 0.07,
+                    "doc_count": 28922
+                },
+                {
+                    "key": 0.08,
+                    "doc_count": 25264
+                },
+                {
+                    "key": 0.09,
+                    "doc_count": 31305
+                },
+                {
+                    "key": 0.1,
+                    "doc_count": 44897
+                },
+                {
+                    "key": 0.11,
+                    "doc_count": 54685
+                },
+                {
+                    "key": 0.12,
+                    "doc_count": 47756
+                },
+                {
+                    "key": 0.13,
+                    "doc_count": 59976
+                },
+                {
+                    "key": 0.14,
+                    "doc_count": 59959
+                },
+                {
+                    "key": 0.15,
+                    "doc_count": 80224
+                },
+                {
+                    "key": 0.16,
+                    "doc_count": 69460
+                },
+                {
+                    "key": 0.17,
+                    "doc_count": 78627
+                },
+                {
+                    "key": 0.18,
+                    "doc_count": 82161
+                },
+                {
+                    "key": 0.19,
+                    "doc_count": 61989
+                },
+                {
+                    "key": 0.2,
+                    "doc_count": 106321
+                },
+                {
+                    "key": 0.21,
+                    "doc_count": 87650
+                },
+                {
+                    "key": 0.22,
+                    "doc_count": 77350
+                },
+                {
+                    "key": 0.23,
+                    "doc_count": 85527
+                },
+                {
+                    "key": 0.24,
+                    "doc_count": 46610
+                },
+                {
+                    "key": 0.25,
+                    "doc_count": 95445
+                },
+                {
+                    "key": 0.26,
+                    "doc_count": 63142
+                },
+                {
+                    "key": 0.27,
+                    "doc_count": 56275
+                },
+                {
+                    "key": 0.28,
+                    "doc_count": 55287
+                },
+                {
+                    "key": 0.29,
+                    "doc_count": 42018
+                },
+                {
+                    "key": 0.3,
+                    "doc_count": 47230
+                },
+                {
+                    "key": 0.31,
+                    "doc_count": 38967
+                },
+                {
+                    "key": 0.32,
+                    "doc_count": 25424
+                },
+                {
+                    "key": 0.33,
+                    "doc_count": 30272
+                },
+                {
+                    "key": 0.34,
+                    "doc_count": 24999
+                },
+                {
+                    "key": 0.35000000000000003,
+                    "doc_count": 16646
+                },
+                {
+                    "key": 0.36,
+                    "doc_count": 16824
+                },
+                {
+                    "key": 0.37,
+                    "doc_count": 13857
+                },
+                {
+                    "key": 0.38,
+                    "doc_count": 11196
+                },
+                {
+                    "key": 0.39,
+                    "doc_count": 6651
+                },
+                {
+                    "key": 0.4,
+                    "doc_count": 10536
+                },
+                {
+                    "key": 0.41000000000000003,
+                    "doc_count": 6370
+                },
+                {
+                    "key": 0.42,
+                    "doc_count": 5711
+                },
+                {
+                    "key": 0.43,
+                    "doc_count": 3949
+                },
+                {
+                    "key": 0.44,
+                    "doc_count": 3528
+                },
+                {
+                    "key": 0.45,
+                    "doc_count": 2518
+                },
+                {
+                    "key": 0.46,
+                    "doc_count": 2386
+                },
+                {
+                    "key": 0.47000000000000003,
+                    "doc_count": 2239
+                },
+                {
+                    "key": 0.48,
+                    "doc_count": 1097
+                },
+                {
+                    "key": 0.49,
+                    "doc_count": 77
+                },
+                {
+                    "key": 0.5,
+                    "doc_count": 2649
+                },
+                {
+                    "key": 0.51,
+                    "doc_count": 654
+                },
+                {
+                    "key": 0.52,
+                    "doc_count": 696
+                },
+                {
+                    "key": 0.53,
+                    "doc_count": 558
+                },
+                {
+                    "key": 0.54,
+                    "doc_count": 430
+                },
+                {
+                    "key": 0.55,
+                    "doc_count": 427
+                },
+                {
+                    "key": 0.56,
+                    "doc_count": 273
+                },
+                {
+                    "key": 0.5700000000000001,
+                    "doc_count": 379
+                },
+                {
+                    "key": 0.58,
+                    "doc_count": 237
+                },
+                {
+                    "key": 0.59,
+                    "doc_count": 92
+                },
+                {
+                    "key": 0.6,
+                    "doc_count": 254
+                },
+                {
+                    "key": 0.61,
+                    "doc_count": 152
+                },
+                {
+                    "key": 0.62,
+                    "doc_count": 103
+                },
+                {
+                    "key": 0.63,
+                    "doc_count": 97
+                },
+                {
+                    "key": 0.64,
+                    "doc_count": 77
+                },
+                {
+                    "key": 0.65,
+                    "doc_count": 23
+                },
+                {
+                    "key": 0.66,
+                    "doc_count": 127
+                },
+                {
+                    "key": 0.67,
+                    "doc_count": 9
+                },
+                {
+                    "key": 0.68,
+                    "doc_count": 36
+                },
+                {
+                    "key": 0.6900000000000001,
+                    "doc_count": 40
+                },
+                {
+                    "key": 0.7000000000000001,
+                    "doc_count": 14
+                },
+                {
+                    "key": 0.71,
+                    "doc_count": 27
+                },
+                {
+                    "key": 0.72,
+                    "doc_count": 19
+                },
+                {
+                    "key": 0.73,
+                    "doc_count": 18
+                },
+                {
+                    "key": 0.74,
+                    "doc_count": 2
+                },
+                {
+                    "key": 0.75,
+                    "doc_count": 29
+                },
+                {
+                    "key": 0.76,
+                    "doc_count": 11
+                },
+                {
+                    "key": 0.77,
+                    "doc_count": 14
+                },
+                {
+                    "key": 0.78,
+                    "doc_count": 8
+                },
+                {
+                    "key": 0.79,
+                    "doc_count": 2
+                },
+                {
+                    "key": 0.8,
+                    "doc_count": 9
+                },
+                {
+                    "key": 0.81,
+                    "doc_count": 9
+                },
+                {
+                    "key": 0.8200000000000001,
+                    "doc_count": 2
+                },
+                {
+                    "key": 0.8300000000000001,
+                    "doc_count": 16
+                },
+                {
+                    "key": 0.84,
+                    "doc_count": 4
+                },
+                {
+                    "key": 0.85,
+                    "doc_count": 2
+                },
+                {
+                    "key": 0.86,
+                    "doc_count": 7
+                },
+                {
+                    "key": 0.87,
+                    "doc_count": 4
+                },
+                {
+                    "key": 0.88,
+                    "doc_count": 6
+                },
+                {
+                    "key": 0.89,
+                    "doc_count": 10
+                },
+                {
+                    "key": 0.9,
+                    "doc_count": 1
+                },
+                {
+                    "key": 0.91,
+                    "doc_count": 2
+                },
+                {
+                    "key": 0.92,
+                    "doc_count": 2
+                },
+                {
+                    "key": 0.93,
+                    "doc_count": 3
+                },
+                {
+                    "key": 0.9400000000000001,
+                    "doc_count": 4
+                },
+                {
+                    "key": 0.9500000000000001,
+                    "doc_count": 5
+                },
+                {
+                    "key": 0.96,
+                    "doc_count": 2
+                },
+                {
+                    "key": 0.97,
+                    "doc_count": 9
+                },
+                {
+                    "key": 0.98,
+                    "doc_count": 1
+                },
+                {
+                    "key": 1.0,
+                    "doc_count": 24
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Provides descriptive statistics for the duplicate metatdata using
the aggregations API.

See README.md for more detail.

closes #61
closes #40
closes #39
closes #38
closes #37