### PR TITLE
Download index script

### DIFF
--- a/src/bin/es/dump.mjs
+++ b/src/bin/es/dump.mjs
@@ -1,0 +1,47 @@
+import { promises as fs } from 'fs'
+
+import { Command } from 'commander';
+import * as _ from 'lamb';
+
+import { arxliveCopy } from 'conf/config.mjs';
+import { dump } from 'es/dump.mjs'
+import { commanderParseInt } from 'util/commander.mjs'
+
+const program = new Command();
+program.option(
+	'-d, --domain <domain>',
+	'ES domain on which to aggregate',
+	arxliveCopy
+);
+program.option(
+	'--indent <value>',
+	'Whether to use an indent for the outputted JSON, and if so, how many spaces',
+	commanderParseInt,
+	0
+)
+program.requiredOption(
+	'-i, --index <index>',
+	'ES index on which to aggregate'
+);
+program.requiredOption(
+	'-o, --out <path>',
+	'Path to directory in which to save results.'
+);
+
+program.parse();
+const options = program.opts();
+
+const main = async () => {
+	const documents = await dump(options.domain, options.index, 10000)
+	await fs.writeFile(
+		`${options.out}/${options.index}.json`,
+		JSON.stringify(documents, null, options.indent)
+	)
+};
+
+main();
+
+/*
+Usage:
+node src/bin/es/dump.mjs --index ai-map --out data/ai_map/
+*/

--- a/src/node_modules/es/dump.mjs
+++ b/src/node_modules/es/dump.mjs
@@ -1,0 +1,41 @@
+import * as _ from 'lamb'
+
+import { SingleBar, Presets } from 'cli-progress'
+
+import { count } from 'es/index.mjs'
+import { scroll, clearScroll } from 'es/search.mjs'
+
+
+/**
+ * 
+ * @param {string} domain - domain on from which to dump data
+ * @param {string} index - index from which to dump data
+ * @param {number} size size of scroll object - how many documents to fetch in a single reqeust. Maximum value is 10k
+ * @returns {Object} list of all documents on that index.
+ */
+export const dump = async(domain, index, size) => {
+    
+    const bar = new SingleBar(
+        { etaBuffer: size * 10 },
+        Presets.rect
+    );
+    
+    const totalDocuments = await count(domain, index);
+    bar.start(totalDocuments, 0);
+    
+    const scroller = scroll(domain, index, {
+        size,
+        pages: 'all'
+    });
+    // mutation required due to await
+    let documents = []
+    for await (let page of scroller) {
+        documents.push(_.map(page.hits.hits, doc => {
+            bar.increment()
+            return doc._source
+        }));
+    }
+    bar.stop();
+	clearScroll(domain)
+    return documents;
+}


### PR DESCRIPTION
PR to introduce a script which uses the scroll API to download the
source data from a given index and output it to a json file.

Also includes the latest version of the annotated AI map data.

closes #94