### PR TITLE
100 fix nested array bug

### DIFF
--- a/src/bin/es/document.mjs
+++ b/src/bin/es/document.mjs
@@ -24,7 +24,6 @@ program
 	arxliveCopy
 )
 .action((index, path, options) => {
-	// eslint-disable-next-line no-sync
 	const parsed = JSON.parse(fs.readFileSync(path));
 	const documents = parsed instanceof Array ? parsed : [parsed];
 	documents.map(async document => {

--- a/src/node_modules/es/dump.mjs
+++ b/src/node_modules/es/dump.mjs
@@ -29,10 +29,12 @@ export const dump = async(domain, index, size) => {
 	// mutation required due to await
 	let documents = [];
 	for await (let page of scroller) {
-		documents.push(_.map(page.hits.hits, doc => {
-			bar.increment();
-			return doc._source;
-		}));
+		documents.push(
+			..._.map(page.hits.hits, doc => {
+				bar.increment();
+				return doc._source;
+			})
+		);
 	}
 	bar.stop();
 	clearScroll(domain);


### PR DESCRIPTION
Fix nested array bug

Fixes a bug where the dump.mjs script was returning a needlessly
nested array of documents.

fixes https://github.com/nestauk/dap_dv_backends/issues/100