### PR TITLE
Retrieve the Dbpedia ontology

### DIFF
--- a/data/dbpedia/ontology.json
+++ b/data/dbpedia/ontology.json
@@ -1,0 +1,5630 @@
+{
+    "http://dbpedia.org/ontology/Publisher": {
+        "class_": "http://dbpedia.org/ontology/Publisher",
+        "parentClass": "http://dbpedia.org/ontology/Company",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Brewery": {
+        "class_": "http://dbpedia.org/ontology/Brewery",
+        "parentClass": "http://dbpedia.org/ontology/Company",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/LawFirm": {
+        "class_": "http://dbpedia.org/ontology/LawFirm",
+        "parentClass": "http://dbpedia.org/ontology/Company",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/PublicTransitSystem": {
+        "class_": "http://dbpedia.org/ontology/PublicTransitSystem",
+        "parentClass": "http://dbpedia.org/ontology/Company",
+        "children": [
+            "http://dbpedia.org/ontology/Airline",
+            "http://dbpedia.org/ontology/BusCompany"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Winery": {
+        "class_": "http://dbpedia.org/ontology/Winery",
+        "parentClass": "http://dbpedia.org/ontology/Company",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Bank": {
+        "class_": "http://dbpedia.org/ontology/Bank",
+        "parentClass": "http://dbpedia.org/ontology/Company",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RecordLabel": {
+        "class_": "http://dbpedia.org/ontology/RecordLabel",
+        "parentClass": "http://dbpedia.org/ontology/Company",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Caterer": {
+        "class_": "http://dbpedia.org/ontology/Caterer",
+        "parentClass": "http://dbpedia.org/ontology/Company",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Sport": {
+        "class_": "http://dbpedia.org/ontology/Sport",
+        "parentClass": "http://dbpedia.org/ontology/Activity",
+        "children": [
+            "http://dbpedia.org/ontology/Athletics",
+            "http://dbpedia.org/ontology/TeamSport"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Game": {
+        "class_": "http://dbpedia.org/ontology/Game",
+        "parentClass": "http://dbpedia.org/ontology/Activity",
+        "children": [
+            "http://dbpedia.org/ontology/BoardGame",
+            "http://dbpedia.org/ontology/CardGame"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Sales": {
+        "class_": "http://dbpedia.org/ontology/Sales",
+        "parentClass": "http://dbpedia.org/ontology/Activity",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Surname": {
+        "class_": "http://dbpedia.org/ontology/Surname",
+        "parentClass": "http://dbpedia.org/ontology/Name",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/GivenName": {
+        "class_": "http://dbpedia.org/ontology/GivenName",
+        "parentClass": "http://dbpedia.org/ontology/Name",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MilitaryPerson": {
+        "class_": "http://dbpedia.org/ontology/MilitaryPerson",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/AmericanLeader": {
+        "class_": "http://dbpedia.org/ontology/AmericanLeader",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/PlayboyPlaymate": {
+        "class_": "http://dbpedia.org/ontology/PlayboyPlaymate",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Presenter": {
+        "class_": "http://dbpedia.org/ontology/Presenter",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/TelevisionHost",
+            "http://dbpedia.org/ontology/RadioHost"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Architect": {
+        "class_": "http://dbpedia.org/ontology/Architect",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/BeautyQueen": {
+        "class_": "http://dbpedia.org/ontology/BeautyQueen",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Cleric": {
+        "class_": "http://dbpedia.org/ontology/Cleric",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/ChristianBishop",
+            "http://dbpedia.org/ontology/Priest",
+            "http://dbpedia.org/ontology/ChristianPatriarch",
+            "http://dbpedia.org/ontology/Cardinal",
+            "http://dbpedia.org/ontology/Saint",
+            "http://dbpedia.org/ontology/Pope",
+            "http://dbpedia.org/ontology/Vicar"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Economist": {
+        "class_": "http://dbpedia.org/ontology/Economist",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Engineer": {
+        "class_": "http://dbpedia.org/ontology/Engineer",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/HorseTrainer": {
+        "class_": "http://dbpedia.org/ontology/HorseTrainer",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Journalist": {
+        "class_": "http://dbpedia.org/ontology/Journalist",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/PoliceOfficer": {
+        "class_": "http://dbpedia.org/ontology/PoliceOfficer",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Scientist": {
+        "class_": "http://dbpedia.org/ontology/Scientist",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/Medician",
+            "http://dbpedia.org/ontology/Entomologist",
+            "http://dbpedia.org/ontology/Biologist",
+            "http://dbpedia.org/ontology/Professor"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Youtuber": {
+        "class_": "http://dbpedia.org/ontology/Youtuber",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Judge": {
+        "class_": "http://dbpedia.org/ontology/Judge",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Astronaut": {
+        "class_": "http://dbpedia.org/ontology/Astronaut",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/BusinessPerson": {
+        "class_": "http://dbpedia.org/ontology/BusinessPerson",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Chef": {
+        "class_": "http://dbpedia.org/ontology/Chef",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Model": {
+        "class_": "http://dbpedia.org/ontology/Model",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Noble": {
+        "class_": "http://dbpedia.org/ontology/Noble",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Pilot": {
+        "class_": "http://dbpedia.org/ontology/Pilot",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Spy": {
+        "class_": "http://dbpedia.org/ontology/Spy",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Coach": {
+        "class_": "http://dbpedia.org/ontology/Coach",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/VolleyballCoach",
+            "http://dbpedia.org/ontology/CollegeCoach",
+            "http://dbpedia.org/ontology/AmericanFootballCoach"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/SportsManager": {
+        "class_": "http://dbpedia.org/ontology/SportsManager",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/SoccerManager"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/OrganisationMember": {
+        "class_": "http://dbpedia.org/ontology/OrganisationMember",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/SportsTeamMember"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Academic": {
+        "class_": "http://dbpedia.org/ontology/Academic",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Artist": {
+        "class_": "http://dbpedia.org/ontology/Artist",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/Actor",
+            "http://dbpedia.org/ontology/Comedian",
+            "http://dbpedia.org/ontology/ComicsCreator",
+            "http://dbpedia.org/ontology/Photographer",
+            "http://dbpedia.org/ontology/Dancer",
+            "http://dbpedia.org/ontology/FashionDesigner",
+            "http://dbpedia.org/ontology/Painter",
+            "http://dbpedia.org/ontology/MusicalArtist",
+            "http://dbpedia.org/ontology/Humorist",
+            "http://dbpedia.org/ontology/Sculptor"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Athlete": {
+        "class_": "http://dbpedia.org/ontology/Athlete",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/HorseRider",
+            "http://dbpedia.org/ontology/BadmintonPlayer",
+            "http://dbpedia.org/ontology/BaseballPlayer",
+            "http://dbpedia.org/ontology/BasketballPlayer",
+            "http://dbpedia.org/ontology/Boxer",
+            "http://dbpedia.org/ontology/ChessPlayer",
+            "http://dbpedia.org/ontology/Cricketer",
+            "http://dbpedia.org/ontology/Cyclist",
+            "http://dbpedia.org/ontology/GolfPlayer",
+            "http://dbpedia.org/ontology/Jockey",
+            "http://dbpedia.org/ontology/LacrossePlayer",
+            "http://dbpedia.org/ontology/MartialArtist",
+            "http://dbpedia.org/ontology/Sailor",
+            "http://dbpedia.org/ontology/SoccerPlayer",
+            "http://dbpedia.org/ontology/Swimmer",
+            "http://dbpedia.org/ontology/TableTennisPlayer",
+            "http://dbpedia.org/ontology/TennisPlayer",
+            "http://dbpedia.org/ontology/VolleyballPlayer",
+            "http://dbpedia.org/ontology/Wrestler",
+            "http://dbpedia.org/ontology/NationalCollegiateAthleticAssociationAthlete",
+            "http://dbpedia.org/ontology/Rower",
+            "http://dbpedia.org/ontology/AustralianRulesFootballPlayer",
+            "http://dbpedia.org/ontology/Bodybuilder",
+            "http://dbpedia.org/ontology/Canoeist",
+            "http://dbpedia.org/ontology/DartsPlayer",
+            "http://dbpedia.org/ontology/GaelicGamesPlayer",
+            "http://dbpedia.org/ontology/Gymnast",
+            "http://dbpedia.org/ontology/HandballPlayer",
+            "http://dbpedia.org/ontology/NetballPlayer",
+            "http://dbpedia.org/ontology/PokerPlayer",
+            "http://dbpedia.org/ontology/SnookerPlayer",
+            "http://dbpedia.org/ontology/SquashPlayer",
+            "http://dbpedia.org/ontology/WinterSportPlayer",
+            "http://dbpedia.org/ontology/GridironFootballPlayer",
+            "http://dbpedia.org/ontology/MotorsportRacer",
+            "http://dbpedia.org/ontology/RugbyPlayer",
+            "http://dbpedia.org/ontology/ArcherPlayer",
+            "http://dbpedia.org/ontology/AthleticsPlayer",
+            "http://dbpedia.org/ontology/BullFighter",
+            "http://dbpedia.org/ontology/Fencer",
+            "http://dbpedia.org/ontology/HighDiver",
+            "http://dbpedia.org/ontology/Surfer",
+            "http://dbpedia.org/ontology/TeamMember",
+            "http://dbpedia.org/ontology/WaterPoloPlayer"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Criminal": {
+        "class_": "http://dbpedia.org/ontology/Criminal",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/Murderer"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Philosopher": {
+        "class_": "http://dbpedia.org/ontology/Philosopher",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Politician": {
+        "class_": "http://dbpedia.org/ontology/Politician",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/Congressman",
+            "http://dbpedia.org/ontology/Governor",
+            "http://dbpedia.org/ontology/Mayor",
+            "http://dbpedia.org/ontology/MemberOfParliament",
+            "http://dbpedia.org/ontology/President",
+            "http://dbpedia.org/ontology/Senator",
+            "http://dbpedia.org/ontology/Ambassador",
+            "http://dbpedia.org/ontology/PrimeMinister",
+            "http://dbpedia.org/ontology/Chancellor",
+            "http://dbpedia.org/ontology/Deputy",
+            "http://dbpedia.org/ontology/Lieutenant",
+            "http://dbpedia.org/ontology/Minister",
+            "http://dbpedia.org/ontology/VicePresident",
+            "http://dbpedia.org/ontology/VicePrimeMinister"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Religious": {
+        "class_": "http://dbpedia.org/ontology/Religious",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/LatterDaySaint",
+            "http://dbpedia.org/ontology/JewishLeader",
+            "http://dbpedia.org/ontology/Rebbe"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Royalty": {
+        "class_": "http://dbpedia.org/ontology/Royalty",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/Pretender",
+            "http://dbpedia.org/ontology/BritishRoyalty",
+            "http://dbpedia.org/ontology/Pharaoh"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Writer": {
+        "class_": "http://dbpedia.org/ontology/Writer",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [
+            "http://dbpedia.org/ontology/Historian",
+            "http://dbpedia.org/ontology/Poet",
+            "http://dbpedia.org/ontology/ScreenWriter",
+            "http://dbpedia.org/ontology/MusicComposer",
+            "http://dbpedia.org/ontology/PlayWright",
+            "http://dbpedia.org/ontology/SongWriter"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Archeologist": {
+        "class_": "http://dbpedia.org/ontology/Archeologist",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Aristocrat": {
+        "class_": "http://dbpedia.org/ontology/Aristocrat",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/DBpedian": {
+        "class_": "http://dbpedia.org/ontology/DBpedian",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Egyptologist": {
+        "class_": "http://dbpedia.org/ontology/Egyptologist",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Farmer": {
+        "class_": "http://dbpedia.org/ontology/Farmer",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Lawyer": {
+        "class_": "http://dbpedia.org/ontology/Lawyer",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Linguist": {
+        "class_": "http://dbpedia.org/ontology/Linguist",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Man": {
+        "class_": "http://dbpedia.org/ontology/Man",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/MemberResistanceMovement": {
+        "class_": "http://dbpedia.org/ontology/MemberResistanceMovement",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/MovieDirector": {
+        "class_": "http://dbpedia.org/ontology/MovieDirector",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/PoliticianSpouse": {
+        "class_": "http://dbpedia.org/ontology/PoliticianSpouse",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Producer": {
+        "class_": "http://dbpedia.org/ontology/Producer",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Psychologist": {
+        "class_": "http://dbpedia.org/ontology/Psychologist",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Referee": {
+        "class_": "http://dbpedia.org/ontology/Referee",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/RomanEmperor": {
+        "class_": "http://dbpedia.org/ontology/RomanEmperor",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/TelevisionDirector": {
+        "class_": "http://dbpedia.org/ontology/TelevisionDirector",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/TheatreDirector": {
+        "class_": "http://dbpedia.org/ontology/TheatreDirector",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Woman": {
+        "class_": "http://dbpedia.org/ontology/Woman",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Monarch": {
+        "class_": "http://dbpedia.org/ontology/Monarch",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/OfficeHolder": {
+        "class_": "http://dbpedia.org/ontology/OfficeHolder",
+        "parentClass": "http://dbpedia.org/ontology/Person",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/VoiceActor": {
+        "class_": "http://dbpedia.org/ontology/VoiceActor",
+        "parentClass": "http://dbpedia.org/ontology/Actor",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/AdultActor": {
+        "class_": "http://dbpedia.org/ontology/AdultActor",
+        "parentClass": "http://dbpedia.org/ontology/Actor",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/ConcentrationCamp": {
+        "class_": "http://dbpedia.org/ontology/ConcentrationCamp",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/SiteOfSpecialScientificInterest": {
+        "class_": "http://dbpedia.org/ontology/SiteOfSpecialScientificInterest",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/WineRegion": {
+        "class_": "http://dbpedia.org/ontology/WineRegion",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Garden": {
+        "class_": "http://dbpedia.org/ontology/Garden",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/PopulatedPlace": {
+        "class_": "http://dbpedia.org/ontology/PopulatedPlace",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [
+            "http://dbpedia.org/ontology/Country",
+            "http://dbpedia.org/ontology/Island",
+            "http://dbpedia.org/ontology/Continent",
+            "http://dbpedia.org/ontology/Region",
+            "http://dbpedia.org/ontology/Settlement",
+            "http://dbpedia.org/ontology/Agglomeration",
+            "http://dbpedia.org/ontology/Community",
+            "http://dbpedia.org/ontology/GatedCommunity",
+            "http://dbpedia.org/ontology/Intercommunality",
+            "http://dbpedia.org/ontology/Locality",
+            "http://dbpedia.org/ontology/State",
+            "http://dbpedia.org/ontology/Street",
+            "http://dbpedia.org/ontology/Territory"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/WorldHeritageSite": {
+        "class_": "http://dbpedia.org/ontology/WorldHeritageSite",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/CelestialBody": {
+        "class_": "http://dbpedia.org/ontology/CelestialBody",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [
+            "http://dbpedia.org/ontology/Galaxy",
+            "http://dbpedia.org/ontology/Constellation",
+            "http://dbpedia.org/ontology/Asteroid",
+            "http://dbpedia.org/ontology/Planet",
+            "http://dbpedia.org/ontology/Star",
+            "http://dbpedia.org/ontology/Nebula",
+            "http://dbpedia.org/ontology/Satellite",
+            "http://dbpedia.org/ontology/Swarm"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/NaturalPlace": {
+        "class_": "http://dbpedia.org/ontology/NaturalPlace",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [
+            "http://dbpedia.org/ontology/Crater",
+            "http://dbpedia.org/ontology/Glacier",
+            "http://dbpedia.org/ontology/Cave",
+            "http://dbpedia.org/ontology/MountainPass",
+            "http://dbpedia.org/ontology/Volcano",
+            "http://dbpedia.org/ontology/BodyOfWater",
+            "http://dbpedia.org/ontology/Mountain",
+            "http://dbpedia.org/ontology/Archipelago",
+            "http://dbpedia.org/ontology/Beach",
+            "http://dbpedia.org/ontology/Cape",
+            "http://dbpedia.org/ontology/Desert",
+            "http://dbpedia.org/ontology/Forest",
+            "http://dbpedia.org/ontology/HotSpring",
+            "http://dbpedia.org/ontology/MountainRange",
+            "http://dbpedia.org/ontology/Valley"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/HistoricPlace": {
+        "class_": "http://dbpedia.org/ontology/HistoricPlace",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Park": {
+        "class_": "http://dbpedia.org/ontology/Park",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/ProtectedArea": {
+        "class_": "http://dbpedia.org/ontology/ProtectedArea",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Cemetery": {
+        "class_": "http://dbpedia.org/ontology/Cemetery",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/CountrySeat": {
+        "class_": "http://dbpedia.org/ontology/CountrySeat",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Mine": {
+        "class_": "http://dbpedia.org/ontology/Mine",
+        "parentClass": "http://dbpedia.org/ontology/Place",
+        "children": [
+            "http://dbpedia.org/ontology/CoalPit"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MusicGenre": {
+        "class_": "http://dbpedia.org/ontology/MusicGenre",
+        "parentClass": "http://dbpedia.org/ontology/Genre",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ArtisticGenre": {
+        "class_": "http://dbpedia.org/ontology/ArtisticGenre",
+        "parentClass": "http://dbpedia.org/ontology/Genre",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/LiteraryGenre": {
+        "class_": "http://dbpedia.org/ontology/LiteraryGenre",
+        "parentClass": "http://dbpedia.org/ontology/Genre",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MovieGenre": {
+        "class_": "http://dbpedia.org/ontology/MovieGenre",
+        "parentClass": "http://dbpedia.org/ontology/Genre",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ProgrammingLanguage": {
+        "class_": "http://dbpedia.org/ontology/ProgrammingLanguage",
+        "parentClass": "http://dbpedia.org/ontology/Language",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/OverseasDepartment": {
+        "class_": "http://dbpedia.org/ontology/OverseasDepartment",
+        "parentClass": "http://dbpedia.org/ontology/Department",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/VideoGame": {
+        "class_": "http://dbpedia.org/ontology/VideoGame",
+        "parentClass": "http://dbpedia.org/ontology/Software",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/DocumentType": {
+        "class_": "http://dbpedia.org/ontology/DocumentType",
+        "parentClass": "http://dbpedia.org/ontology/Type",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/GovernmentType": {
+        "class_": "http://dbpedia.org/ontology/GovernmentType",
+        "parentClass": "http://dbpedia.org/ontology/Type",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/AmericanFootballLeague": {
+        "class_": "http://dbpedia.org/ontology/AmericanFootballLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/VolleyballLeague": {
+        "class_": "http://dbpedia.org/ontology/VolleyballLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/BaseballLeague": {
+        "class_": "http://dbpedia.org/ontology/BaseballLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CanadianFootballLeague": {
+        "class_": "http://dbpedia.org/ontology/CanadianFootballLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/GolfLeague": {
+        "class_": "http://dbpedia.org/ontology/GolfLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CurlingLeague": {
+        "class_": "http://dbpedia.org/ontology/CurlingLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/AustralianFootballLeague": {
+        "class_": "http://dbpedia.org/ontology/AustralianFootballLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/AutoRacingLeague": {
+        "class_": "http://dbpedia.org/ontology/AutoRacingLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/MixedMartialArtsLeague": {
+        "class_": "http://dbpedia.org/ontology/MixedMartialArtsLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/MotorcycleRacingLeague": {
+        "class_": "http://dbpedia.org/ontology/MotorcycleRacingLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/PoloLeague": {
+        "class_": "http://dbpedia.org/ontology/PoloLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/HandballLeague": {
+        "class_": "http://dbpedia.org/ontology/HandballLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/IceHockeyLeague": {
+        "class_": "http://dbpedia.org/ontology/IceHockeyLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/BoxingLeague": {
+        "class_": "http://dbpedia.org/ontology/BoxingLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/BowlingLeague": {
+        "class_": "http://dbpedia.org/ontology/BowlingLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RugbyLeague": {
+        "class_": "http://dbpedia.org/ontology/RugbyLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/SoccerLeague": {
+        "class_": "http://dbpedia.org/ontology/SoccerLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/VideogamesLeague": {
+        "class_": "http://dbpedia.org/ontology/VideogamesLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/InlineHockeyLeague": {
+        "class_": "http://dbpedia.org/ontology/InlineHockeyLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/FieldHockeyLeague": {
+        "class_": "http://dbpedia.org/ontology/FieldHockeyLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CricketLeague": {
+        "class_": "http://dbpedia.org/ontology/CricketLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/LacrosseLeague": {
+        "class_": "http://dbpedia.org/ontology/LacrosseLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/SpeedwayLeague": {
+        "class_": "http://dbpedia.org/ontology/SpeedwayLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/SoftballLeague": {
+        "class_": "http://dbpedia.org/ontology/SoftballLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/TennisLeague": {
+        "class_": "http://dbpedia.org/ontology/TennisLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CyclingLeague": {
+        "class_": "http://dbpedia.org/ontology/CyclingLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/FormulaOneRacing": {
+        "class_": "http://dbpedia.org/ontology/FormulaOneRacing",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/PaintballLeague": {
+        "class_": "http://dbpedia.org/ontology/PaintballLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RadioControlledRacingLeague": {
+        "class_": "http://dbpedia.org/ontology/RadioControlledRacingLeague",
+        "parentClass": "http://dbpedia.org/ontology/SportsLeague",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/River": {
+        "class_": "http://dbpedia.org/ontology/River",
+        "parentClass": "http://dbpedia.org/ontology/Stream",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Canal": {
+        "class_": "http://dbpedia.org/ontology/Canal",
+        "parentClass": "http://dbpedia.org/ontology/Stream",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Tunnel": {
+        "class_": "http://dbpedia.org/ontology/Tunnel",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/SportFacility": {
+        "class_": "http://dbpedia.org/ontology/SportFacility",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/SkiArea",
+            "http://dbpedia.org/ontology/CricketGround",
+            "http://dbpedia.org/ontology/GolfCourse",
+            "http://dbpedia.org/ontology/RaceTrack"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Tower": {
+        "class_": "http://dbpedia.org/ontology/Tower",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/Lighthouse",
+            "http://dbpedia.org/ontology/WaterTower"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Infrastructure": {
+        "class_": "http://dbpedia.org/ontology/Infrastructure",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/Dam",
+            "http://dbpedia.org/ontology/RouteOfTransportation",
+            "http://dbpedia.org/ontology/LaunchPad",
+            "http://dbpedia.org/ontology/Airport",
+            "http://dbpedia.org/ontology/PowerStation",
+            "http://dbpedia.org/ontology/Station",
+            "http://dbpedia.org/ontology/Dike",
+            "http://dbpedia.org/ontology/Lock",
+            "http://dbpedia.org/ontology/Port",
+            "http://dbpedia.org/ontology/RestArea"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/AmusementParkAttraction": {
+        "class_": "http://dbpedia.org/ontology/AmusementParkAttraction",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/RollerCoaster",
+            "http://dbpedia.org/ontology/WaterRide"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Building": {
+        "class_": "http://dbpedia.org/ontology/Building",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/Prison",
+            "http://dbpedia.org/ontology/Skyscraper",
+            "http://dbpedia.org/ontology/Castle",
+            "http://dbpedia.org/ontology/ReligiousBuilding",
+            "http://dbpedia.org/ontology/HistoricBuilding",
+            "http://dbpedia.org/ontology/Hospital",
+            "http://dbpedia.org/ontology/Hotel",
+            "http://dbpedia.org/ontology/Museum",
+            "http://dbpedia.org/ontology/Restaurant",
+            "http://dbpedia.org/ontology/ShoppingMall",
+            "http://dbpedia.org/ontology/Venue",
+            "http://dbpedia.org/ontology/Casino",
+            "http://dbpedia.org/ontology/Factory"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MilitaryStructure": {
+        "class_": "http://dbpedia.org/ontology/MilitaryStructure",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/Fort"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Monument": {
+        "class_": "http://dbpedia.org/ontology/Monument",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/GraveMonument",
+            "http://dbpedia.org/ontology/Memorial"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Arena": {
+        "class_": "http://dbpedia.org/ontology/Arena",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Infrastucture": {
+        "class_": "http://dbpedia.org/ontology/Infrastucture",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/ElectricalSubstation"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Mill": {
+        "class_": "http://dbpedia.org/ontology/Mill",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [
+            "http://dbpedia.org/ontology/Treadmill",
+            "http://dbpedia.org/ontology/Watermill",
+            "http://dbpedia.org/ontology/WindMotor",
+            "http://dbpedia.org/ontology/Windmill"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Pyramid": {
+        "class_": "http://dbpedia.org/ontology/Pyramid",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Square": {
+        "class_": "http://dbpedia.org/ontology/Square",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Zoo": {
+        "class_": "http://dbpedia.org/ontology/Zoo",
+        "parentClass": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/TelevisionHost": {
+        "class_": "http://dbpedia.org/ontology/TelevisionHost",
+        "parentClass": "http://dbpedia.org/ontology/Presenter",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/RadioHost": {
+        "class_": "http://dbpedia.org/ontology/RadioHost",
+        "parentClass": "http://dbpedia.org/ontology/Presenter",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/AmateurBoxer": {
+        "class_": "http://dbpedia.org/ontology/AmateurBoxer",
+        "parentClass": "http://dbpedia.org/ontology/Boxer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/MilitaryService": {
+        "class_": "http://dbpedia.org/ontology/MilitaryService",
+        "parentClass": "http://dbpedia.org/ontology/CareerStation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Archbishop": {
+        "class_": "http://dbpedia.org/ontology/Archbishop",
+        "parentClass": "http://dbpedia.org/ontology/ChristianBishop",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/ChristianBishop": {
+        "class_": "http://dbpedia.org/ontology/ChristianBishop",
+        "parentClass": "http://dbpedia.org/ontology/Cleric",
+        "children": [
+            "http://dbpedia.org/ontology/Archbishop"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Priest": {
+        "class_": "http://dbpedia.org/ontology/Priest",
+        "parentClass": "http://dbpedia.org/ontology/Cleric",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/ChristianPatriarch": {
+        "class_": "http://dbpedia.org/ontology/ChristianPatriarch",
+        "parentClass": "http://dbpedia.org/ontology/Cleric",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Cardinal": {
+        "class_": "http://dbpedia.org/ontology/Cardinal",
+        "parentClass": "http://dbpedia.org/ontology/Cleric",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Saint": {
+        "class_": "http://dbpedia.org/ontology/Saint",
+        "parentClass": "http://dbpedia.org/ontology/Cleric",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Pope": {
+        "class_": "http://dbpedia.org/ontology/Pope",
+        "parentClass": "http://dbpedia.org/ontology/Cleric",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Vicar": {
+        "class_": "http://dbpedia.org/ontology/Vicar",
+        "parentClass": "http://dbpedia.org/ontology/Cleric",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/HistoricalCountry": {
+        "class_": "http://dbpedia.org/ontology/HistoricalCountry",
+        "parentClass": "http://dbpedia.org/ontology/Country",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/LunarCrater": {
+        "class_": "http://dbpedia.org/ontology/LunarCrater",
+        "parentClass": "http://dbpedia.org/ontology/Crater",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Atoll": {
+        "class_": "http://dbpedia.org/ontology/Atoll",
+        "parentClass": "http://dbpedia.org/ontology/Island",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Horse": {
+        "class_": "http://dbpedia.org/ontology/Horse",
+        "parentClass": "http://dbpedia.org/ontology/Mammal",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Cat": {
+        "class_": "http://dbpedia.org/ontology/Cat",
+        "parentClass": "http://dbpedia.org/ontology/Mammal",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Dog": {
+        "class_": "http://dbpedia.org/ontology/Dog",
+        "parentClass": "http://dbpedia.org/ontology/Mammal",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Airline": {
+        "class_": "http://dbpedia.org/ontology/Airline",
+        "parentClass": "http://dbpedia.org/ontology/PublicTransitSystem",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/BusCompany": {
+        "class_": "http://dbpedia.org/ontology/BusCompany",
+        "parentClass": "http://dbpedia.org/ontology/PublicTransitSystem",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Medician": {
+        "class_": "http://dbpedia.org/ontology/Medician",
+        "parentClass": "http://dbpedia.org/ontology/Scientist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Entomologist": {
+        "class_": "http://dbpedia.org/ontology/Entomologist",
+        "parentClass": "http://dbpedia.org/ontology/Scientist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Biologist": {
+        "class_": "http://dbpedia.org/ontology/Biologist",
+        "parentClass": "http://dbpedia.org/ontology/Scientist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Professor": {
+        "class_": "http://dbpedia.org/ontology/Professor",
+        "parentClass": "http://dbpedia.org/ontology/Scientist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/SkiResort": {
+        "class_": "http://dbpedia.org/ontology/SkiResort",
+        "parentClass": "http://dbpedia.org/ontology/SkiArea",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Athletics": {
+        "class_": "http://dbpedia.org/ontology/Athletics",
+        "parentClass": "http://dbpedia.org/ontology/Sport",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/TeamSport": {
+        "class_": "http://dbpedia.org/ontology/TeamSport",
+        "parentClass": "http://dbpedia.org/ontology/Sport",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/BeachVolleyballPlayer": {
+        "class_": "http://dbpedia.org/ontology/BeachVolleyballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/VolleyballPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/SumoWrestler": {
+        "class_": "http://dbpedia.org/ontology/SumoWrestler",
+        "parentClass": "http://dbpedia.org/ontology/Wrestler",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Embryology": {
+        "class_": "http://dbpedia.org/ontology/Embryology",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Lymph": {
+        "class_": "http://dbpedia.org/ontology/Lymph",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Artery": {
+        "class_": "http://dbpedia.org/ontology/Artery",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Bone": {
+        "class_": "http://dbpedia.org/ontology/Bone",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Brain": {
+        "class_": "http://dbpedia.org/ontology/Brain",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Ligament": {
+        "class_": "http://dbpedia.org/ontology/Ligament",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Muscle": {
+        "class_": "http://dbpedia.org/ontology/Muscle",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Nerve": {
+        "class_": "http://dbpedia.org/ontology/Nerve",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Vein": {
+        "class_": "http://dbpedia.org/ontology/Vein",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/BloodVessel": {
+        "class_": "http://dbpedia.org/ontology/BloodVessel",
+        "parentClass": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Person": {
+        "class_": "http://dbpedia.org/ontology/Person",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [
+            "http://dbpedia.org/ontology/MilitaryPerson",
+            "http://dbpedia.org/ontology/AmericanLeader",
+            "http://dbpedia.org/ontology/PlayboyPlaymate",
+            "http://dbpedia.org/ontology/Presenter",
+            "http://dbpedia.org/ontology/Architect",
+            "http://dbpedia.org/ontology/BeautyQueen",
+            "http://dbpedia.org/ontology/Cleric",
+            "http://dbpedia.org/ontology/Economist",
+            "http://dbpedia.org/ontology/Engineer",
+            "http://dbpedia.org/ontology/HorseTrainer",
+            "http://dbpedia.org/ontology/Journalist",
+            "http://dbpedia.org/ontology/PoliceOfficer",
+            "http://dbpedia.org/ontology/Scientist",
+            "http://dbpedia.org/ontology/Youtuber",
+            "http://dbpedia.org/ontology/Judge",
+            "http://dbpedia.org/ontology/Astronaut",
+            "http://dbpedia.org/ontology/BusinessPerson",
+            "http://dbpedia.org/ontology/Chef",
+            "http://dbpedia.org/ontology/Model",
+            "http://dbpedia.org/ontology/Noble",
+            "http://dbpedia.org/ontology/Pilot",
+            "http://dbpedia.org/ontology/Spy",
+            "http://dbpedia.org/ontology/Coach",
+            "http://dbpedia.org/ontology/SportsManager",
+            "http://dbpedia.org/ontology/OrganisationMember",
+            "http://dbpedia.org/ontology/Academic",
+            "http://dbpedia.org/ontology/Artist",
+            "http://dbpedia.org/ontology/Athlete",
+            "http://dbpedia.org/ontology/Criminal",
+            "http://dbpedia.org/ontology/Philosopher",
+            "http://dbpedia.org/ontology/Politician",
+            "http://dbpedia.org/ontology/Religious",
+            "http://dbpedia.org/ontology/Royalty",
+            "http://dbpedia.org/ontology/Writer",
+            "http://dbpedia.org/ontology/Archeologist",
+            "http://dbpedia.org/ontology/Aristocrat",
+            "http://dbpedia.org/ontology/DBpedian",
+            "http://dbpedia.org/ontology/Egyptologist",
+            "http://dbpedia.org/ontology/Farmer",
+            "http://dbpedia.org/ontology/Lawyer",
+            "http://dbpedia.org/ontology/Linguist",
+            "http://dbpedia.org/ontology/Man",
+            "http://dbpedia.org/ontology/MemberResistanceMovement",
+            "http://dbpedia.org/ontology/MovieDirector",
+            "http://dbpedia.org/ontology/PoliticianSpouse",
+            "http://dbpedia.org/ontology/Producer",
+            "http://dbpedia.org/ontology/Psychologist",
+            "http://dbpedia.org/ontology/Referee",
+            "http://dbpedia.org/ontology/RomanEmperor",
+            "http://dbpedia.org/ontology/TelevisionDirector",
+            "http://dbpedia.org/ontology/TheatreDirector",
+            "http://dbpedia.org/ontology/Woman",
+            "http://dbpedia.org/ontology/Monarch",
+            "http://dbpedia.org/ontology/OfficeHolder"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Mammal": {
+        "class_": "http://dbpedia.org/ontology/Mammal",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [
+            "http://dbpedia.org/ontology/Horse",
+            "http://dbpedia.org/ontology/Cat",
+            "http://dbpedia.org/ontology/Dog"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Amphibian": {
+        "class_": "http://dbpedia.org/ontology/Amphibian",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Arachnid": {
+        "class_": "http://dbpedia.org/ontology/Arachnid",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Crustacean": {
+        "class_": "http://dbpedia.org/ontology/Crustacean",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Fish": {
+        "class_": "http://dbpedia.org/ontology/Fish",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Insect": {
+        "class_": "http://dbpedia.org/ontology/Insect",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Mollusca": {
+        "class_": "http://dbpedia.org/ontology/Mollusca",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Reptile": {
+        "class_": "http://dbpedia.org/ontology/Reptile",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Bird": {
+        "class_": "http://dbpedia.org/ontology/Bird",
+        "parentClass": "http://dbpedia.org/ontology/Animal",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/School": {
+        "class_": "http://dbpedia.org/ontology/School",
+        "parentClass": "http://dbpedia.org/ontology/EducationalInstitution",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/College": {
+        "class_": "http://dbpedia.org/ontology/College",
+        "parentClass": "http://dbpedia.org/ontology/EducationalInstitution",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/University": {
+        "class_": "http://dbpedia.org/ontology/University",
+        "parentClass": "http://dbpedia.org/ontology/EducationalInstitution",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Library": {
+        "class_": "http://dbpedia.org/ontology/Library",
+        "parentClass": "http://dbpedia.org/ontology/EducationalInstitution",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Animal": {
+        "class_": "http://dbpedia.org/ontology/Animal",
+        "parentClass": "http://dbpedia.org/ontology/Eukaryote",
+        "children": [
+            "http://dbpedia.org/ontology/Person",
+            "http://dbpedia.org/ontology/Mammal",
+            "http://dbpedia.org/ontology/Amphibian",
+            "http://dbpedia.org/ontology/Arachnid",
+            "http://dbpedia.org/ontology/Crustacean",
+            "http://dbpedia.org/ontology/Fish",
+            "http://dbpedia.org/ontology/Insect",
+            "http://dbpedia.org/ontology/Mollusca",
+            "http://dbpedia.org/ontology/Reptile",
+            "http://dbpedia.org/ontology/Bird"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Fungus": {
+        "class_": "http://dbpedia.org/ontology/Fungus",
+        "parentClass": "http://dbpedia.org/ontology/Eukaryote",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Plant": {
+        "class_": "http://dbpedia.org/ontology/Plant",
+        "parentClass": "http://dbpedia.org/ontology/Eukaryote",
+        "children": [
+            "http://dbpedia.org/ontology/Gnetophytes",
+            "http://dbpedia.org/ontology/Ginkgo",
+            "http://dbpedia.org/ontology/Conifer",
+            "http://dbpedia.org/ontology/GreenAlga",
+            "http://dbpedia.org/ontology/Cycad",
+            "http://dbpedia.org/ontology/FloweringPlant",
+            "http://dbpedia.org/ontology/ClubMoss",
+            "http://dbpedia.org/ontology/CultivatedVariety",
+            "http://dbpedia.org/ontology/Moss",
+            "http://dbpedia.org/ontology/Fern"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SpeedwayRider": {
+        "class_": "http://dbpedia.org/ontology/SpeedwayRider",
+        "parentClass": "http://dbpedia.org/ontology/MotorcycleRider",
+        "children": [],
+        "depth": 8
+    },
+    "http://dbpedia.org/ontology/MotocycleRacer": {
+        "class_": "http://dbpedia.org/ontology/MotocycleRacer",
+        "parentClass": "http://dbpedia.org/ontology/MotorcycleRider",
+        "children": [],
+        "depth": 8
+    },
+    "http://dbpedia.org/ontology/Country": {
+        "class_": "http://dbpedia.org/ontology/Country",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [
+            "http://dbpedia.org/ontology/HistoricalCountry"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Island": {
+        "class_": "http://dbpedia.org/ontology/Island",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [
+            "http://dbpedia.org/ontology/Atoll"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Continent": {
+        "class_": "http://dbpedia.org/ontology/Continent",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Region": {
+        "class_": "http://dbpedia.org/ontology/Region",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [
+            "http://dbpedia.org/ontology/AdministrativeRegion",
+            "http://dbpedia.org/ontology/NaturalRegion"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Settlement": {
+        "class_": "http://dbpedia.org/ontology/Settlement",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [
+            "http://dbpedia.org/ontology/City",
+            "http://dbpedia.org/ontology/CityDistrict",
+            "http://dbpedia.org/ontology/Town",
+            "http://dbpedia.org/ontology/Village",
+            "http://dbpedia.org/ontology/HistoricalSettlement"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Agglomeration": {
+        "class_": "http://dbpedia.org/ontology/Agglomeration",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Community": {
+        "class_": "http://dbpedia.org/ontology/Community",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/GatedCommunity": {
+        "class_": "http://dbpedia.org/ontology/GatedCommunity",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Intercommunality": {
+        "class_": "http://dbpedia.org/ontology/Intercommunality",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Locality": {
+        "class_": "http://dbpedia.org/ontology/Locality",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/State": {
+        "class_": "http://dbpedia.org/ontology/State",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Street": {
+        "class_": "http://dbpedia.org/ontology/Street",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Territory": {
+        "class_": "http://dbpedia.org/ontology/Territory",
+        "parentClass": "http://dbpedia.org/ontology/PopulatedPlace",
+        "children": [
+            "http://dbpedia.org/ontology/OldTerritory"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SnookerChamp": {
+        "class_": "http://dbpedia.org/ontology/SnookerChamp",
+        "parentClass": "http://dbpedia.org/ontology/SnookerPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Archaea": {
+        "class_": "http://dbpedia.org/ontology/Archaea",
+        "parentClass": "http://dbpedia.org/ontology/Species",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Bacteria": {
+        "class_": "http://dbpedia.org/ontology/Bacteria",
+        "parentClass": "http://dbpedia.org/ontology/Species",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Eukaryote": {
+        "class_": "http://dbpedia.org/ontology/Eukaryote",
+        "parentClass": "http://dbpedia.org/ontology/Species",
+        "children": [
+            "http://dbpedia.org/ontology/Animal",
+            "http://dbpedia.org/ontology/Fungus",
+            "http://dbpedia.org/ontology/Plant"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Genre": {
+        "class_": "http://dbpedia.org/ontology/Genre",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [
+            "http://dbpedia.org/ontology/MusicGenre",
+            "http://dbpedia.org/ontology/ArtisticGenre",
+            "http://dbpedia.org/ontology/LiteraryGenre",
+            "http://dbpedia.org/ontology/MovieGenre"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Type": {
+        "class_": "http://dbpedia.org/ontology/Type",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [
+            "http://dbpedia.org/ontology/DocumentType",
+            "http://dbpedia.org/ontology/GovernmentType"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Fashion": {
+        "class_": "http://dbpedia.org/ontology/Fashion",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/AcademicSubject": {
+        "class_": "http://dbpedia.org/ontology/AcademicSubject",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/CardinalDirection": {
+        "class_": "http://dbpedia.org/ontology/CardinalDirection",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Ideology": {
+        "class_": "http://dbpedia.org/ontology/Ideology",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MathematicalConcept": {
+        "class_": "http://dbpedia.org/ontology/MathematicalConcept",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/PhilosophicalConcept": {
+        "class_": "http://dbpedia.org/ontology/PhilosophicalConcept",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/PoliticalConcept": {
+        "class_": "http://dbpedia.org/ontology/PoliticalConcept",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/ScientificConcept": {
+        "class_": "http://dbpedia.org/ontology/ScientificConcept",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Standard": {
+        "class_": "http://dbpedia.org/ontology/Standard",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/SystemOfLaw": {
+        "class_": "http://dbpedia.org/ontology/SystemOfLaw",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Tax": {
+        "class_": "http://dbpedia.org/ontology/Tax",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Taxon": {
+        "class_": "http://dbpedia.org/ontology/Taxon",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/TheologicalConcept": {
+        "class_": "http://dbpedia.org/ontology/TheologicalConcept",
+        "parentClass": "http://dbpedia.org/ontology/TopicalConcept",
+        "children": [
+            "http://dbpedia.org/ontology/ChristianDoctrine"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/BasketballLeague": {
+        "class_": "http://dbpedia.org/ontology/BasketballLeague",
+        "parentClass": "http://dbpedia.org/ontology/کھیلوں_کی_انجمن",
+        "children": []
+    },
+    "http://dbpedia.org/ontology/VolleyballCoach": {
+        "class_": "http://dbpedia.org/ontology/VolleyballCoach",
+        "parentClass": "http://dbpedia.org/ontology/Coach",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/CollegeCoach": {
+        "class_": "http://dbpedia.org/ontology/CollegeCoach",
+        "parentClass": "http://dbpedia.org/ontology/Coach",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/AmericanFootballCoach": {
+        "class_": "http://dbpedia.org/ontology/AmericanFootballCoach",
+        "parentClass": "http://dbpedia.org/ontology/Coach",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/SoccerManager": {
+        "class_": "http://dbpedia.org/ontology/SoccerManager",
+        "parentClass": "http://dbpedia.org/ontology/SportsManager",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/FigureSkater": {
+        "class_": "http://dbpedia.org/ontology/FigureSkater",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/IceHockeyPlayer": {
+        "class_": "http://dbpedia.org/ontology/IceHockeyPlayer",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Skier": {
+        "class_": "http://dbpedia.org/ontology/Skier",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Curler": {
+        "class_": "http://dbpedia.org/ontology/Curler",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Skater": {
+        "class_": "http://dbpedia.org/ontology/Skater",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Biathlete": {
+        "class_": "http://dbpedia.org/ontology/Biathlete",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/BobsleighAthlete": {
+        "class_": "http://dbpedia.org/ontology/BobsleighAthlete",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/CrossCountrySkier": {
+        "class_": "http://dbpedia.org/ontology/CrossCountrySkier",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/NordicCombined": {
+        "class_": "http://dbpedia.org/ontology/NordicCombined",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Ski_jumper": {
+        "class_": "http://dbpedia.org/ontology/Ski_jumper",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/SpeedSkater": {
+        "class_": "http://dbpedia.org/ontology/SpeedSkater",
+        "parentClass": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/BiologicalDatabase": {
+        "class_": "http://dbpedia.org/ontology/BiologicalDatabase",
+        "parentClass": "http://dbpedia.org/ontology/Database",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SkiArea": {
+        "class_": "http://dbpedia.org/ontology/SkiArea",
+        "parentClass": "http://dbpedia.org/ontology/SportFacility",
+        "children": [
+            "http://dbpedia.org/ontology/SkiResort"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/CricketGround": {
+        "class_": "http://dbpedia.org/ontology/CricketGround",
+        "parentClass": "http://dbpedia.org/ontology/SportFacility",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/GolfCourse": {
+        "class_": "http://dbpedia.org/ontology/GolfCourse",
+        "parentClass": "http://dbpedia.org/ontology/SportFacility",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/RaceTrack": {
+        "class_": "http://dbpedia.org/ontology/RaceTrack",
+        "parentClass": "http://dbpedia.org/ontology/SportFacility",
+        "children": [
+            "http://dbpedia.org/ontology/Racecourse"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Department": {
+        "class_": "http://dbpedia.org/ontology/Department",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [
+            "http://dbpedia.org/ontology/OverseasDepartment"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Municipality": {
+        "class_": "http://dbpedia.org/ontology/Municipality",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [
+            "http://dbpedia.org/ontology/FormerMunicipality"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Arrondissement": {
+        "class_": "http://dbpedia.org/ontology/Arrondissement",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Canton": {
+        "class_": "http://dbpedia.org/ontology/Canton",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/District": {
+        "class_": "http://dbpedia.org/ontology/District",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [
+            "http://dbpedia.org/ontology/HistoricalDistrict"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/DistrictWaterBoard": {
+        "class_": "http://dbpedia.org/ontology/DistrictWaterBoard",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/MicroRegion": {
+        "class_": "http://dbpedia.org/ontology/MicroRegion",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Prefecture": {
+        "class_": "http://dbpedia.org/ontology/Prefecture",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Province": {
+        "class_": "http://dbpedia.org/ontology/Province",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [
+            "http://dbpedia.org/ontology/HistoricalProvince"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Regency": {
+        "class_": "http://dbpedia.org/ontology/Regency",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/SubMunicipality": {
+        "class_": "http://dbpedia.org/ontology/SubMunicipality",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/FormerMunicipality": {
+        "class_": "http://dbpedia.org/ontology/FormerMunicipality",
+        "parentClass": "http://dbpedia.org/ontology/Municipality",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Racecourse": {
+        "class_": "http://dbpedia.org/ontology/Racecourse",
+        "parentClass": "http://dbpedia.org/ontology/RaceTrack",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Lighthouse": {
+        "class_": "http://dbpedia.org/ontology/Lighthouse",
+        "parentClass": "http://dbpedia.org/ontology/Tower",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/WaterTower": {
+        "class_": "http://dbpedia.org/ontology/WaterTower",
+        "parentClass": "http://dbpedia.org/ontology/Tower",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Baronet": {
+        "class_": "http://dbpedia.org/ontology/Baronet",
+        "parentClass": "http://dbpedia.org/ontology/BritishRoyalty",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/SoapCharacter": {
+        "class_": "http://dbpedia.org/ontology/SoapCharacter",
+        "parentClass": "http://dbpedia.org/ontology/FictionalCharacter",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MythologicalFigure": {
+        "class_": "http://dbpedia.org/ontology/MythologicalFigure",
+        "parentClass": "http://dbpedia.org/ontology/FictionalCharacter",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ComicsCharacter": {
+        "class_": "http://dbpedia.org/ontology/ComicsCharacter",
+        "parentClass": "http://dbpedia.org/ontology/FictionalCharacter",
+        "children": [
+            "http://dbpedia.org/ontology/AnimangaCharacter"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/DisneyCharacter": {
+        "class_": "http://dbpedia.org/ontology/DisneyCharacter",
+        "parentClass": "http://dbpedia.org/ontology/FictionalCharacter",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/NarutoCharacter": {
+        "class_": "http://dbpedia.org/ontology/NarutoCharacter",
+        "parentClass": "http://dbpedia.org/ontology/FictionalCharacter",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Church": {
+        "class_": "http://dbpedia.org/ontology/Church",
+        "parentClass": "http://dbpedia.org/ontology/ReligiousBuilding",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Monastery": {
+        "class_": "http://dbpedia.org/ontology/Monastery",
+        "parentClass": "http://dbpedia.org/ontology/ReligiousBuilding",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Mosque": {
+        "class_": "http://dbpedia.org/ontology/Mosque",
+        "parentClass": "http://dbpedia.org/ontology/ReligiousBuilding",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Shrine": {
+        "class_": "http://dbpedia.org/ontology/Shrine",
+        "parentClass": "http://dbpedia.org/ontology/ReligiousBuilding",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Synagogue": {
+        "class_": "http://dbpedia.org/ontology/Synagogue",
+        "parentClass": "http://dbpedia.org/ontology/ReligiousBuilding",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Temple": {
+        "class_": "http://dbpedia.org/ontology/Temple",
+        "parentClass": "http://dbpedia.org/ontology/ReligiousBuilding",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/LightNovel": {
+        "class_": "http://dbpedia.org/ontology/LightNovel",
+        "parentClass": "http://dbpedia.org/ontology/Novel",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/MovingImage": {
+        "class_": "http://dbpedia.org/ontology/MovingImage",
+        "parentClass": "http://dbpedia.org/ontology/Image",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/StillImage": {
+        "class_": "http://dbpedia.org/ontology/StillImage",
+        "parentClass": "http://dbpedia.org/ontology/Image",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Gene": {
+        "class_": "http://dbpedia.org/ontology/Gene",
+        "parentClass": "http://dbpedia.org/ontology/Biomolecule",
+        "children": [
+            "http://dbpedia.org/ontology/HumanGene",
+            "http://dbpedia.org/ontology/MouseGene"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Enzyme": {
+        "class_": "http://dbpedia.org/ontology/Enzyme",
+        "parentClass": "http://dbpedia.org/ontology/Biomolecule",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Protein": {
+        "class_": "http://dbpedia.org/ontology/Protein",
+        "parentClass": "http://dbpedia.org/ontology/Biomolecule",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Hormone": {
+        "class_": "http://dbpedia.org/ontology/Hormone",
+        "parentClass": "http://dbpedia.org/ontology/Biomolecule",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Lipid": {
+        "class_": "http://dbpedia.org/ontology/Lipid",
+        "parentClass": "http://dbpedia.org/ontology/Biomolecule",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Polysaccharide": {
+        "class_": "http://dbpedia.org/ontology/Polysaccharide",
+        "parentClass": "http://dbpedia.org/ontology/Biomolecule",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Galaxy": {
+        "class_": "http://dbpedia.org/ontology/Galaxy",
+        "parentClass": "http://dbpedia.org/ontology/CelestialBody",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Constellation": {
+        "class_": "http://dbpedia.org/ontology/Constellation",
+        "parentClass": "http://dbpedia.org/ontology/CelestialBody",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Asteroid": {
+        "class_": "http://dbpedia.org/ontology/Asteroid",
+        "parentClass": "http://dbpedia.org/ontology/CelestialBody",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Planet": {
+        "class_": "http://dbpedia.org/ontology/Planet",
+        "parentClass": "http://dbpedia.org/ontology/CelestialBody",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Star": {
+        "class_": "http://dbpedia.org/ontology/Star",
+        "parentClass": "http://dbpedia.org/ontology/CelestialBody",
+        "children": [
+            "http://dbpedia.org/ontology/BrownDwarf"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Nebula": {
+        "class_": "http://dbpedia.org/ontology/Nebula",
+        "parentClass": "http://dbpedia.org/ontology/CelestialBody",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Satellite": {
+        "class_": "http://dbpedia.org/ontology/Satellite",
+        "parentClass": "http://dbpedia.org/ontology/CelestialBody",
+        "children": [
+            "http://dbpedia.org/ontology/ArtificialSatellite"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Swarm": {
+        "class_": "http://dbpedia.org/ontology/Swarm",
+        "parentClass": "http://dbpedia.org/ontology/CelestialBody",
+        "children": [
+            "http://dbpedia.org/ontology/Globularswarm",
+            "http://dbpedia.org/ontology/Openswarm"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Mineral": {
+        "class_": "http://dbpedia.org/ontology/Mineral",
+        "parentClass": "http://dbpedia.org/ontology/ChemicalSubstance",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/ChemicalCompound": {
+        "class_": "http://dbpedia.org/ontology/ChemicalCompound",
+        "parentClass": "http://dbpedia.org/ontology/ChemicalSubstance",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Drug": {
+        "class_": "http://dbpedia.org/ontology/Drug",
+        "parentClass": "http://dbpedia.org/ontology/ChemicalSubstance",
+        "children": [
+            "http://dbpedia.org/ontology/CombinationDrug",
+            "http://dbpedia.org/ontology/MonoclonalAntibody",
+            "http://dbpedia.org/ontology/Vaccine",
+            "http://dbpedia.org/ontology/VaccinationStatistics"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/ChemicalElement": {
+        "class_": "http://dbpedia.org/ontology/ChemicalElement",
+        "parentClass": "http://dbpedia.org/ontology/ChemicalSubstance",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/HumanGene": {
+        "class_": "http://dbpedia.org/ontology/HumanGene",
+        "parentClass": "http://dbpedia.org/ontology/Gene",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MouseGene": {
+        "class_": "http://dbpedia.org/ontology/MouseGene",
+        "parentClass": "http://dbpedia.org/ontology/Gene",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/TopLevelDomain": {
+        "class_": "http://dbpedia.org/ontology/TopLevelDomain",
+        "parentClass": "http://dbpedia.org/ontology/Identifier",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Dam": {
+        "class_": "http://dbpedia.org/ontology/Dam",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/RouteOfTransportation": {
+        "class_": "http://dbpedia.org/ontology/RouteOfTransportation",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [
+            "http://dbpedia.org/ontology/RailwayTunnel",
+            "http://dbpedia.org/ontology/RoadTunnel",
+            "http://dbpedia.org/ontology/Bridge",
+            "http://dbpedia.org/ontology/RailwayLine",
+            "http://dbpedia.org/ontology/Road",
+            "http://dbpedia.org/ontology/RoadJunction",
+            "http://dbpedia.org/ontology/WaterwayTunnel"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/LaunchPad": {
+        "class_": "http://dbpedia.org/ontology/LaunchPad",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Airport": {
+        "class_": "http://dbpedia.org/ontology/Airport",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/PowerStation": {
+        "class_": "http://dbpedia.org/ontology/PowerStation",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [
+            "http://dbpedia.org/ontology/NuclearPowerStation"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Station": {
+        "class_": "http://dbpedia.org/ontology/Station",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [
+            "http://dbpedia.org/ontology/RailwayStation",
+            "http://dbpedia.org/ontology/MetroStation",
+            "http://dbpedia.org/ontology/RouteStop",
+            "http://dbpedia.org/ontology/TramStation"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Dike": {
+        "class_": "http://dbpedia.org/ontology/Dike",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Lock": {
+        "class_": "http://dbpedia.org/ontology/Lock",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Port": {
+        "class_": "http://dbpedia.org/ontology/Port",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/RestArea": {
+        "class_": "http://dbpedia.org/ontology/RestArea",
+        "parentClass": "http://dbpedia.org/ontology/Infrastructure",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Motorcycle": {
+        "class_": "http://dbpedia.org/ontology/Motorcycle",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Rocket": {
+        "class_": "http://dbpedia.org/ontology/Rocket",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Locomotive": {
+        "class_": "http://dbpedia.org/ontology/Locomotive",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/SpaceShuttle": {
+        "class_": "http://dbpedia.org/ontology/SpaceShuttle",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/SpaceStation": {
+        "class_": "http://dbpedia.org/ontology/SpaceStation",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Aircraft": {
+        "class_": "http://dbpedia.org/ontology/Aircraft",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [
+            "http://dbpedia.org/ontology/MilitaryAircraft"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Automobile": {
+        "class_": "http://dbpedia.org/ontology/Automobile",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Ship": {
+        "class_": "http://dbpedia.org/ontology/Ship",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Train": {
+        "class_": "http://dbpedia.org/ontology/Train",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MilitaryVehicle": {
+        "class_": "http://dbpedia.org/ontology/MilitaryVehicle",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/On-SiteTransportation": {
+        "class_": "http://dbpedia.org/ontology/On-SiteTransportation",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [
+            "http://dbpedia.org/ontology/ConveyorSystem",
+            "http://dbpedia.org/ontology/Escalator",
+            "http://dbpedia.org/ontology/MovingWalkway"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/TrainCarriage": {
+        "class_": "http://dbpedia.org/ontology/TrainCarriage",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Tram": {
+        "class_": "http://dbpedia.org/ontology/Tram",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Spacecraft": {
+        "class_": "http://dbpedia.org/ontology/Spacecraft",
+        "parentClass": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/SolarEclipse": {
+        "class_": "http://dbpedia.org/ontology/SolarEclipse",
+        "parentClass": "http://dbpedia.org/ontology/NaturalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Earthquake": {
+        "class_": "http://dbpedia.org/ontology/Earthquake",
+        "parentClass": "http://dbpedia.org/ontology/NaturalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/StormSurge": {
+        "class_": "http://dbpedia.org/ontology/StormSurge",
+        "parentClass": "http://dbpedia.org/ontology/NaturalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Crater": {
+        "class_": "http://dbpedia.org/ontology/Crater",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [
+            "http://dbpedia.org/ontology/LunarCrater"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Glacier": {
+        "class_": "http://dbpedia.org/ontology/Glacier",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Cave": {
+        "class_": "http://dbpedia.org/ontology/Cave",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MountainPass": {
+        "class_": "http://dbpedia.org/ontology/MountainPass",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Volcano": {
+        "class_": "http://dbpedia.org/ontology/Volcano",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/BodyOfWater": {
+        "class_": "http://dbpedia.org/ontology/BodyOfWater",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [
+            "http://dbpedia.org/ontology/Stream",
+            "http://dbpedia.org/ontology/Bay",
+            "http://dbpedia.org/ontology/Sea",
+            "http://dbpedia.org/ontology/Lake",
+            "http://dbpedia.org/ontology/Ocean"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Mountain": {
+        "class_": "http://dbpedia.org/ontology/Mountain",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Archipelago": {
+        "class_": "http://dbpedia.org/ontology/Archipelago",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Beach": {
+        "class_": "http://dbpedia.org/ontology/Beach",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Cape": {
+        "class_": "http://dbpedia.org/ontology/Cape",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Desert": {
+        "class_": "http://dbpedia.org/ontology/Desert",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Forest": {
+        "class_": "http://dbpedia.org/ontology/Forest",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/HotSpring": {
+        "class_": "http://dbpedia.org/ontology/HotSpring",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MountainRange": {
+        "class_": "http://dbpedia.org/ontology/MountainRange",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Valley": {
+        "class_": "http://dbpedia.org/ontology/Valley",
+        "parentClass": "http://dbpedia.org/ontology/NaturalPlace",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SportsTeamMember": {
+        "class_": "http://dbpedia.org/ontology/SportsTeamMember",
+        "parentClass": "http://dbpedia.org/ontology/OrganisationMember",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/ResearchProject": {
+        "class_": "http://dbpedia.org/ontology/ResearchProject",
+        "parentClass": "http://dbpedia.org/ontology/Project",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/CyclingRace": {
+        "class_": "http://dbpedia.org/ontology/CyclingRace",
+        "parentClass": "http://dbpedia.org/ontology/Race",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/HorseRace": {
+        "class_": "http://dbpedia.org/ontology/HorseRace",
+        "parentClass": "http://dbpedia.org/ontology/Race",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/MotorRace": {
+        "class_": "http://dbpedia.org/ontology/MotorRace",
+        "parentClass": "http://dbpedia.org/ontology/Race",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/RailwayTunnel": {
+        "class_": "http://dbpedia.org/ontology/RailwayTunnel",
+        "parentClass": "http://dbpedia.org/ontology/RouteOfTransportation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RoadTunnel": {
+        "class_": "http://dbpedia.org/ontology/RoadTunnel",
+        "parentClass": "http://dbpedia.org/ontology/RouteOfTransportation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Bridge": {
+        "class_": "http://dbpedia.org/ontology/Bridge",
+        "parentClass": "http://dbpedia.org/ontology/RouteOfTransportation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RailwayLine": {
+        "class_": "http://dbpedia.org/ontology/RailwayLine",
+        "parentClass": "http://dbpedia.org/ontology/RouteOfTransportation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Road": {
+        "class_": "http://dbpedia.org/ontology/Road",
+        "parentClass": "http://dbpedia.org/ontology/RouteOfTransportation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RoadJunction": {
+        "class_": "http://dbpedia.org/ontology/RoadJunction",
+        "parentClass": "http://dbpedia.org/ontology/RouteOfTransportation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/WaterwayTunnel": {
+        "class_": "http://dbpedia.org/ontology/WaterwayTunnel",
+        "parentClass": "http://dbpedia.org/ontology/RouteOfTransportation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RugbyClub": {
+        "class_": "http://dbpedia.org/ontology/RugbyClub",
+        "parentClass": "http://dbpedia.org/ontology/SportsClub",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/SoccerClub": {
+        "class_": "http://dbpedia.org/ontology/SoccerClub",
+        "parentClass": "http://dbpedia.org/ontology/SportsClub",
+        "children": [
+            "http://dbpedia.org/ontology/NationalSoccerClub"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/HockeyClub": {
+        "class_": "http://dbpedia.org/ontology/HockeyClub",
+        "parentClass": "http://dbpedia.org/ontology/SportsClub",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Project": {
+        "class_": "http://dbpedia.org/ontology/Project",
+        "parentClass": "http://dbpedia.org/ontology/UnitOfWork",
+        "children": [
+            "http://dbpedia.org/ontology/ResearchProject"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Case": {
+        "class_": "http://dbpedia.org/ontology/Case",
+        "parentClass": "http://dbpedia.org/ontology/UnitOfWork",
+        "children": [
+            "http://dbpedia.org/ontology/LegalCase"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Deity": {
+        "class_": "http://dbpedia.org/ontology/Deity",
+        "parentClass": "http://dbpedia.org/ontology/Agent",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/FictionalCharacter": {
+        "class_": "http://dbpedia.org/ontology/FictionalCharacter",
+        "parentClass": "http://dbpedia.org/ontology/Agent",
+        "children": [
+            "http://dbpedia.org/ontology/SoapCharacter",
+            "http://dbpedia.org/ontology/MythologicalFigure",
+            "http://dbpedia.org/ontology/ComicsCharacter",
+            "http://dbpedia.org/ontology/DisneyCharacter",
+            "http://dbpedia.org/ontology/NarutoCharacter"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Organisation": {
+        "class_": "http://dbpedia.org/ontology/Organisation",
+        "parentClass": "http://dbpedia.org/ontology/Agent",
+        "children": [
+            "http://dbpedia.org/ontology/Company",
+            "http://dbpedia.org/ontology/SportsLeague",
+            "http://dbpedia.org/ontology/EducationalInstitution",
+            "http://dbpedia.org/ontology/SportsClub",
+            "http://dbpedia.org/ontology/Broadcaster",
+            "http://dbpedia.org/ontology/Group",
+            "http://dbpedia.org/ontology/GovernmentAgency",
+            "http://dbpedia.org/ontology/Legislature",
+            "http://dbpedia.org/ontology/MilitaryUnit",
+            "http://dbpedia.org/ontology/PoliticalParty",
+            "http://dbpedia.org/ontology/SportsTeam",
+            "http://dbpedia.org/ontology/TradeUnion",
+            "http://dbpedia.org/ontology/Non-ProfitOrganisation",
+            "http://dbpedia.org/ontology/EmployersOrganisation",
+            "http://dbpedia.org/ontology/GeopoliticalOrganisation",
+            "http://dbpedia.org/ontology/InternationalOrganisation",
+            "http://dbpedia.org/ontology/Parliament",
+            "http://dbpedia.org/ontology/ReligiousOrganisation",
+            "http://dbpedia.org/ontology/SambaSchool",
+            "http://dbpedia.org/ontology/TermOfOffice"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Employer": {
+        "class_": "http://dbpedia.org/ontology/Employer",
+        "parentClass": "http://dbpedia.org/ontology/Agent",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Family": {
+        "class_": "http://dbpedia.org/ontology/Family",
+        "parentClass": "http://dbpedia.org/ontology/Agent",
+        "children": [
+            "http://dbpedia.org/ontology/NobleFamily"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/BroadcastNetwork": {
+        "class_": "http://dbpedia.org/ontology/BroadcastNetwork",
+        "parentClass": "http://dbpedia.org/ontology/Broadcaster",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RadioStation": {
+        "class_": "http://dbpedia.org/ontology/RadioStation",
+        "parentClass": "http://dbpedia.org/ontology/Broadcaster",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/TelevisionStation": {
+        "class_": "http://dbpedia.org/ontology/TelevisionStation",
+        "parentClass": "http://dbpedia.org/ontology/Broadcaster",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Anime": {
+        "class_": "http://dbpedia.org/ontology/Anime",
+        "parentClass": "http://dbpedia.org/ontology/Cartoon",
+        "children": []
+    },
+    "http://dbpedia.org/ontology/HollywoodCartoon": {
+        "class_": "http://dbpedia.org/ontology/HollywoodCartoon",
+        "parentClass": "http://dbpedia.org/ontology/Cartoon",
+        "children": []
+    },
+    "http://dbpedia.org/ontology/LegalCase": {
+        "class_": "http://dbpedia.org/ontology/LegalCase",
+        "parentClass": "http://dbpedia.org/ontology/Case",
+        "children": [
+            "http://dbpedia.org/ontology/SupremeCourtOfTheUnitedStatesCase"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Image": {
+        "class_": "http://dbpedia.org/ontology/Image",
+        "parentClass": "http://dbpedia.org/ontology/Document",
+        "children": [
+            "http://dbpedia.org/ontology/MovingImage",
+            "http://dbpedia.org/ontology/StillImage"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Sound": {
+        "class_": "http://dbpedia.org/ontology/Sound",
+        "parentClass": "http://dbpedia.org/ontology/Document",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/File": {
+        "class_": "http://dbpedia.org/ontology/File",
+        "parentClass": "http://dbpedia.org/ontology/Document",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/AmericanFootballPlayer": {
+        "class_": "http://dbpedia.org/ontology/AmericanFootballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/GridironFootballPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/CanadianFootballPlayer": {
+        "class_": "http://dbpedia.org/ontology/CanadianFootballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/GridironFootballPlayer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Band": {
+        "class_": "http://dbpedia.org/ontology/Band",
+        "parentClass": "http://dbpedia.org/ontology/Group",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/ComedyGroup": {
+        "class_": "http://dbpedia.org/ontology/ComedyGroup",
+        "parentClass": "http://dbpedia.org/ontology/Group",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/SupremeCourtOfTheUnitedStatesCase": {
+        "class_": "http://dbpedia.org/ontology/SupremeCourtOfTheUnitedStatesCase",
+        "parentClass": "http://dbpedia.org/ontology/LegalCase",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/MotorcycleRider": {
+        "class_": "http://dbpedia.org/ontology/MotorcycleRider",
+        "parentClass": "http://dbpedia.org/ontology/MotorsportRacer",
+        "children": [
+            "http://dbpedia.org/ontology/SpeedwayRider",
+            "http://dbpedia.org/ontology/MotocycleRacer"
+        ],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/RacingDriver": {
+        "class_": "http://dbpedia.org/ontology/RacingDriver",
+        "parentClass": "http://dbpedia.org/ontology/MotorsportRacer",
+        "children": [
+            "http://dbpedia.org/ontology/NascarDriver",
+            "http://dbpedia.org/ontology/FormulaOneRacer",
+            "http://dbpedia.org/ontology/DTMRacer",
+            "http://dbpedia.org/ontology/RallyDriver"
+        ],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/AcademicJournal": {
+        "class_": "http://dbpedia.org/ontology/AcademicJournal",
+        "parentClass": "http://dbpedia.org/ontology/PeriodicalLiterature",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Magazine": {
+        "class_": "http://dbpedia.org/ontology/Magazine",
+        "parentClass": "http://dbpedia.org/ontology/PeriodicalLiterature",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Newspaper": {
+        "class_": "http://dbpedia.org/ontology/Newspaper",
+        "parentClass": "http://dbpedia.org/ontology/PeriodicalLiterature",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/UndergroundJournal": {
+        "class_": "http://dbpedia.org/ontology/UndergroundJournal",
+        "parentClass": "http://dbpedia.org/ontology/PeriodicalLiterature",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/AdministrativeRegion": {
+        "class_": "http://dbpedia.org/ontology/AdministrativeRegion",
+        "parentClass": "http://dbpedia.org/ontology/Region",
+        "children": [
+            "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+            "http://dbpedia.org/ontology/HistoricalAreaOfAuthority"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/NaturalRegion": {
+        "class_": "http://dbpedia.org/ontology/NaturalRegion",
+        "parentClass": "http://dbpedia.org/ontology/Region",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/MusicFestival": {
+        "class_": "http://dbpedia.org/ontology/MusicFestival",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/AcademicConference": {
+        "class_": "http://dbpedia.org/ontology/AcademicConference",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/HistoricalEvent": {
+        "class_": "http://dbpedia.org/ontology/HistoricalEvent",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Convention": {
+        "class_": "http://dbpedia.org/ontology/Convention",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Election": {
+        "class_": "http://dbpedia.org/ontology/Election",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/FilmFestival": {
+        "class_": "http://dbpedia.org/ontology/FilmFestival",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MilitaryConflict": {
+        "class_": "http://dbpedia.org/ontology/MilitaryConflict",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SpaceMission": {
+        "class_": "http://dbpedia.org/ontology/SpaceMission",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SportsEvent": {
+        "class_": "http://dbpedia.org/ontology/SportsEvent",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [
+            "http://dbpedia.org/ontology/NationalFootballLeagueEvent",
+            "http://dbpedia.org/ontology/Race",
+            "http://dbpedia.org/ontology/Tournament",
+            "http://dbpedia.org/ontology/FootballMatch",
+            "http://dbpedia.org/ontology/GrandPrix",
+            "http://dbpedia.org/ontology/MixedMartialArtsEvent",
+            "http://dbpedia.org/ontology/Olympics",
+            "http://dbpedia.org/ontology/WrestlingEvent",
+            "http://dbpedia.org/ontology/CyclingCompetition",
+            "http://dbpedia.org/ontology/InternationalFootballLeagueEvent"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Attack": {
+        "class_": "http://dbpedia.org/ontology/Attack",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Meeting": {
+        "class_": "http://dbpedia.org/ontology/Meeting",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Rebellion": {
+        "class_": "http://dbpedia.org/ontology/Rebellion",
+        "parentClass": "http://dbpedia.org/ontology/SocietalEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/BaseballSeason": {
+        "class_": "http://dbpedia.org/ontology/BaseballSeason",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeamSeason",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/FootballLeagueSeason": {
+        "class_": "http://dbpedia.org/ontology/FootballLeagueSeason",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeamSeason",
+        "children": [
+            "http://dbpedia.org/ontology/NationalFootballLeagueSeason"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/NCAATeamSeason": {
+        "class_": "http://dbpedia.org/ontology/NCAATeamSeason",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeamSeason",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SoccerClubSeason": {
+        "class_": "http://dbpedia.org/ontology/SoccerClubSeason",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeamSeason",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SoccerLeagueSeason": {
+        "class_": "http://dbpedia.org/ontology/SoccerLeagueSeason",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeamSeason",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/GolfTournament": {
+        "class_": "http://dbpedia.org/ontology/GolfTournament",
+        "parentClass": "http://dbpedia.org/ontology/Tournament",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/SoccerTournament": {
+        "class_": "http://dbpedia.org/ontology/SoccerTournament",
+        "parentClass": "http://dbpedia.org/ontology/Tournament",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/TennisTournament": {
+        "class_": "http://dbpedia.org/ontology/TennisTournament",
+        "parentClass": "http://dbpedia.org/ontology/Tournament",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/WomensTennisAssociationTournament": {
+        "class_": "http://dbpedia.org/ontology/WomensTennisAssociationTournament",
+        "parentClass": "http://dbpedia.org/ontology/Tournament",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Software": {
+        "class_": "http://dbpedia.org/ontology/Software",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [
+            "http://dbpedia.org/ontology/VideoGame"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Database": {
+        "class_": "http://dbpedia.org/ontology/Database",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [
+            "http://dbpedia.org/ontology/BiologicalDatabase"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Document": {
+        "class_": "http://dbpedia.org/ontology/Document",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [
+            "http://dbpedia.org/ontology/Image",
+            "http://dbpedia.org/ontology/Sound",
+            "http://dbpedia.org/ontology/File"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Artwork": {
+        "class_": "http://dbpedia.org/ontology/Artwork",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [
+            "http://dbpedia.org/ontology/Painting",
+            "http://dbpedia.org/ontology/Sculpture"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Film": {
+        "class_": "http://dbpedia.org/ontology/Film",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/RadioProgram": {
+        "class_": "http://dbpedia.org/ontology/RadioProgram",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/TelevisionEpisode": {
+        "class_": "http://dbpedia.org/ontology/TelevisionEpisode",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/TelevisionSeason": {
+        "class_": "http://dbpedia.org/ontology/TelevisionSeason",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/TelevisionShow": {
+        "class_": "http://dbpedia.org/ontology/TelevisionShow",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Website": {
+        "class_": "http://dbpedia.org/ontology/Website",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/WrittenWork": {
+        "class_": "http://dbpedia.org/ontology/WrittenWork",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [
+            "http://dbpedia.org/ontology/Poem",
+            "http://dbpedia.org/ontology/PeriodicalLiterature",
+            "http://dbpedia.org/ontology/Book",
+            "http://dbpedia.org/ontology/Comic",
+            "http://dbpedia.org/ontology/Play",
+            "http://dbpedia.org/ontology/Annotation",
+            "http://dbpedia.org/ontology/Article",
+            "http://dbpedia.org/ontology/Drama",
+            "http://dbpedia.org/ontology/Law",
+            "http://dbpedia.org/ontology/Letter",
+            "http://dbpedia.org/ontology/MultiVolumePublication",
+            "http://dbpedia.org/ontology/Quote",
+            "http://dbpedia.org/ontology/Resume",
+            "http://dbpedia.org/ontology/StatedResolution",
+            "http://dbpedia.org/ontology/Treaty"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MusicalWork": {
+        "class_": "http://dbpedia.org/ontology/MusicalWork",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [
+            "http://dbpedia.org/ontology/Single",
+            "http://dbpedia.org/ontology/Album",
+            "http://dbpedia.org/ontology/ArtistDiscography",
+            "http://dbpedia.org/ontology/ClassicalMusicComposition",
+            "http://dbpedia.org/ontology/Musical",
+            "http://dbpedia.org/ontology/Song",
+            "http://dbpedia.org/ontology/NationalAnthem",
+            "http://dbpedia.org/ontology/Opera"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/CollectionOfValuables": {
+        "class_": "http://dbpedia.org/ontology/CollectionOfValuables",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/LineOfFashion": {
+        "class_": "http://dbpedia.org/ontology/LineOfFashion",
+        "parentClass": "http://dbpedia.org/ontology/Work",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Cartoon": {
+        "class_": "http://dbpedia.org/ontology/Cartoon",
+        "parentClass": "http://dbpedia.org/ontology/work",
+        "children": [
+            "http://dbpedia.org/ontology/Anime",
+            "http://dbpedia.org/ontology/HollywoodCartoon"
+        ]
+    },
+    "http://dbpedia.org/ontology/Grape": {
+        "class_": "http://dbpedia.org/ontology/Grape",
+        "parentClass": "http://dbpedia.org/ontology/FloweringPlant",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Guitarist": {
+        "class_": "http://dbpedia.org/ontology/Guitarist",
+        "parentClass": "http://dbpedia.org/ontology/Instrumentalist",
+        "children": [],
+        "depth": 8
+    },
+    "http://dbpedia.org/ontology/SnookerWorldRanking": {
+        "class_": "http://dbpedia.org/ontology/SnookerWorldRanking",
+        "parentClass": "http://dbpedia.org/ontology/SportCompetitionResult",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/OlympicResult": {
+        "class_": "http://dbpedia.org/ontology/OlympicResult",
+        "parentClass": "http://dbpedia.org/ontology/SportCompetitionResult",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion": {
+        "class_": "http://dbpedia.org/ontology/GovernmentalAdministrativeRegion",
+        "parentClass": "http://dbpedia.org/ontology/AdministrativeRegion",
+        "children": [
+            "http://dbpedia.org/ontology/Department",
+            "http://dbpedia.org/ontology/Municipality",
+            "http://dbpedia.org/ontology/Arrondissement",
+            "http://dbpedia.org/ontology/Canton",
+            "http://dbpedia.org/ontology/District",
+            "http://dbpedia.org/ontology/DistrictWaterBoard",
+            "http://dbpedia.org/ontology/MicroRegion",
+            "http://dbpedia.org/ontology/Prefecture",
+            "http://dbpedia.org/ontology/Province",
+            "http://dbpedia.org/ontology/Regency",
+            "http://dbpedia.org/ontology/SubMunicipality"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/HistoricalAreaOfAuthority": {
+        "class_": "http://dbpedia.org/ontology/HistoricalAreaOfAuthority",
+        "parentClass": "http://dbpedia.org/ontology/AdministrativeRegion",
+        "children": [
+            "http://dbpedia.org/ontology/Manor"
+        ],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/MilitaryAircraft": {
+        "class_": "http://dbpedia.org/ontology/MilitaryAircraft",
+        "parentClass": "http://dbpedia.org/ontology/Aircraft",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/RollerCoaster": {
+        "class_": "http://dbpedia.org/ontology/RollerCoaster",
+        "parentClass": "http://dbpedia.org/ontology/AmusementParkAttraction",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/WaterRide": {
+        "class_": "http://dbpedia.org/ontology/WaterRide",
+        "parentClass": "http://dbpedia.org/ontology/AmusementParkAttraction",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Actor": {
+        "class_": "http://dbpedia.org/ontology/Actor",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [
+            "http://dbpedia.org/ontology/VoiceActor",
+            "http://dbpedia.org/ontology/AdultActor"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Comedian": {
+        "class_": "http://dbpedia.org/ontology/Comedian",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/ComicsCreator": {
+        "class_": "http://dbpedia.org/ontology/ComicsCreator",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Photographer": {
+        "class_": "http://dbpedia.org/ontology/Photographer",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Dancer": {
+        "class_": "http://dbpedia.org/ontology/Dancer",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/FashionDesigner": {
+        "class_": "http://dbpedia.org/ontology/FashionDesigner",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Painter": {
+        "class_": "http://dbpedia.org/ontology/Painter",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/MusicalArtist": {
+        "class_": "http://dbpedia.org/ontology/MusicalArtist",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [
+            "http://dbpedia.org/ontology/ClassicalMusicArtist",
+            "http://dbpedia.org/ontology/Instrumentalist",
+            "http://dbpedia.org/ontology/BackScene",
+            "http://dbpedia.org/ontology/MusicDirector",
+            "http://dbpedia.org/ontology/Singer"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Humorist": {
+        "class_": "http://dbpedia.org/ontology/Humorist",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Sculptor": {
+        "class_": "http://dbpedia.org/ontology/Sculptor",
+        "parentClass": "http://dbpedia.org/ontology/Artist",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Painting": {
+        "class_": "http://dbpedia.org/ontology/Painting",
+        "parentClass": "http://dbpedia.org/ontology/Artwork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Sculpture": {
+        "class_": "http://dbpedia.org/ontology/Sculpture",
+        "parentClass": "http://dbpedia.org/ontology/Artwork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/HorseRider": {
+        "class_": "http://dbpedia.org/ontology/HorseRider",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/BadmintonPlayer": {
+        "class_": "http://dbpedia.org/ontology/BadmintonPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/BaseballPlayer": {
+        "class_": "http://dbpedia.org/ontology/BaseballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/BasketballPlayer": {
+        "class_": "http://dbpedia.org/ontology/BasketballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Boxer": {
+        "class_": "http://dbpedia.org/ontology/Boxer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [
+            "http://dbpedia.org/ontology/AmateurBoxer"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/ChessPlayer": {
+        "class_": "http://dbpedia.org/ontology/ChessPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Cricketer": {
+        "class_": "http://dbpedia.org/ontology/Cricketer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Cyclist": {
+        "class_": "http://dbpedia.org/ontology/Cyclist",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/GolfPlayer": {
+        "class_": "http://dbpedia.org/ontology/GolfPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Jockey": {
+        "class_": "http://dbpedia.org/ontology/Jockey",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/LacrossePlayer": {
+        "class_": "http://dbpedia.org/ontology/LacrossePlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/MartialArtist": {
+        "class_": "http://dbpedia.org/ontology/MartialArtist",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Sailor": {
+        "class_": "http://dbpedia.org/ontology/Sailor",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/SoccerPlayer": {
+        "class_": "http://dbpedia.org/ontology/SoccerPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Swimmer": {
+        "class_": "http://dbpedia.org/ontology/Swimmer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/TableTennisPlayer": {
+        "class_": "http://dbpedia.org/ontology/TableTennisPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/TennisPlayer": {
+        "class_": "http://dbpedia.org/ontology/TennisPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/VolleyballPlayer": {
+        "class_": "http://dbpedia.org/ontology/VolleyballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [
+            "http://dbpedia.org/ontology/BeachVolleyballPlayer"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Wrestler": {
+        "class_": "http://dbpedia.org/ontology/Wrestler",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [
+            "http://dbpedia.org/ontology/SumoWrestler"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/NationalCollegiateAthleticAssociationAthlete": {
+        "class_": "http://dbpedia.org/ontology/NationalCollegiateAthleticAssociationAthlete",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Rower": {
+        "class_": "http://dbpedia.org/ontology/Rower",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/AustralianRulesFootballPlayer": {
+        "class_": "http://dbpedia.org/ontology/AustralianRulesFootballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Bodybuilder": {
+        "class_": "http://dbpedia.org/ontology/Bodybuilder",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Canoeist": {
+        "class_": "http://dbpedia.org/ontology/Canoeist",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/DartsPlayer": {
+        "class_": "http://dbpedia.org/ontology/DartsPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/GaelicGamesPlayer": {
+        "class_": "http://dbpedia.org/ontology/GaelicGamesPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Gymnast": {
+        "class_": "http://dbpedia.org/ontology/Gymnast",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/HandballPlayer": {
+        "class_": "http://dbpedia.org/ontology/HandballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/NetballPlayer": {
+        "class_": "http://dbpedia.org/ontology/NetballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/PokerPlayer": {
+        "class_": "http://dbpedia.org/ontology/PokerPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/SnookerPlayer": {
+        "class_": "http://dbpedia.org/ontology/SnookerPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [
+            "http://dbpedia.org/ontology/SnookerChamp"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/SquashPlayer": {
+        "class_": "http://dbpedia.org/ontology/SquashPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/WinterSportPlayer": {
+        "class_": "http://dbpedia.org/ontology/WinterSportPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [
+            "http://dbpedia.org/ontology/FigureSkater",
+            "http://dbpedia.org/ontology/IceHockeyPlayer",
+            "http://dbpedia.org/ontology/Skier",
+            "http://dbpedia.org/ontology/Curler",
+            "http://dbpedia.org/ontology/Skater",
+            "http://dbpedia.org/ontology/Biathlete",
+            "http://dbpedia.org/ontology/BobsleighAthlete",
+            "http://dbpedia.org/ontology/CrossCountrySkier",
+            "http://dbpedia.org/ontology/NordicCombined",
+            "http://dbpedia.org/ontology/Ski_jumper",
+            "http://dbpedia.org/ontology/SpeedSkater"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/GridironFootballPlayer": {
+        "class_": "http://dbpedia.org/ontology/GridironFootballPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [
+            "http://dbpedia.org/ontology/AmericanFootballPlayer",
+            "http://dbpedia.org/ontology/CanadianFootballPlayer"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/MotorsportRacer": {
+        "class_": "http://dbpedia.org/ontology/MotorsportRacer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [
+            "http://dbpedia.org/ontology/MotorcycleRider",
+            "http://dbpedia.org/ontology/RacingDriver"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/RugbyPlayer": {
+        "class_": "http://dbpedia.org/ontology/RugbyPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/ArcherPlayer": {
+        "class_": "http://dbpedia.org/ontology/ArcherPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/AthleticsPlayer": {
+        "class_": "http://dbpedia.org/ontology/AthleticsPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/BullFighter": {
+        "class_": "http://dbpedia.org/ontology/BullFighter",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Fencer": {
+        "class_": "http://dbpedia.org/ontology/Fencer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/HighDiver": {
+        "class_": "http://dbpedia.org/ontology/HighDiver",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Surfer": {
+        "class_": "http://dbpedia.org/ontology/Surfer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/TeamMember": {
+        "class_": "http://dbpedia.org/ontology/TeamMember",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/WaterPoloPlayer": {
+        "class_": "http://dbpedia.org/ontology/WaterPoloPlayer",
+        "parentClass": "http://dbpedia.org/ontology/Athlete",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Decoration": {
+        "class_": "http://dbpedia.org/ontology/Decoration",
+        "parentClass": "http://dbpedia.org/ontology/Award",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/NobelPrize": {
+        "class_": "http://dbpedia.org/ontology/NobelPrize",
+        "parentClass": "http://dbpedia.org/ontology/Award",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Beer": {
+        "class_": "http://dbpedia.org/ontology/Beer",
+        "parentClass": "http://dbpedia.org/ontology/Beverage",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Vodka": {
+        "class_": "http://dbpedia.org/ontology/Vodka",
+        "parentClass": "http://dbpedia.org/ontology/Beverage",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Wine": {
+        "class_": "http://dbpedia.org/ontology/Wine",
+        "parentClass": "http://dbpedia.org/ontology/Beverage",
+        "children": [
+            "http://dbpedia.org/ontology/ControlledDesignationOfOriginWine"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Stream": {
+        "class_": "http://dbpedia.org/ontology/Stream",
+        "parentClass": "http://dbpedia.org/ontology/BodyOfWater",
+        "children": [
+            "http://dbpedia.org/ontology/River",
+            "http://dbpedia.org/ontology/Canal"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Bay": {
+        "class_": "http://dbpedia.org/ontology/Bay",
+        "parentClass": "http://dbpedia.org/ontology/BodyOfWater",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Sea": {
+        "class_": "http://dbpedia.org/ontology/Sea",
+        "parentClass": "http://dbpedia.org/ontology/BodyOfWater",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Lake": {
+        "class_": "http://dbpedia.org/ontology/Lake",
+        "parentClass": "http://dbpedia.org/ontology/BodyOfWater",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Ocean": {
+        "class_": "http://dbpedia.org/ontology/Ocean",
+        "parentClass": "http://dbpedia.org/ontology/BodyOfWater",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Novel": {
+        "class_": "http://dbpedia.org/ontology/Novel",
+        "parentClass": "http://dbpedia.org/ontology/Book",
+        "children": [
+            "http://dbpedia.org/ontology/LightNovel"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Prison": {
+        "class_": "http://dbpedia.org/ontology/Prison",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Skyscraper": {
+        "class_": "http://dbpedia.org/ontology/Skyscraper",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Castle": {
+        "class_": "http://dbpedia.org/ontology/Castle",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ReligiousBuilding": {
+        "class_": "http://dbpedia.org/ontology/ReligiousBuilding",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [
+            "http://dbpedia.org/ontology/Church",
+            "http://dbpedia.org/ontology/Monastery",
+            "http://dbpedia.org/ontology/Mosque",
+            "http://dbpedia.org/ontology/Shrine",
+            "http://dbpedia.org/ontology/Synagogue",
+            "http://dbpedia.org/ontology/Temple"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/HistoricBuilding": {
+        "class_": "http://dbpedia.org/ontology/HistoricBuilding",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Hospital": {
+        "class_": "http://dbpedia.org/ontology/Hospital",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Hotel": {
+        "class_": "http://dbpedia.org/ontology/Hotel",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Museum": {
+        "class_": "http://dbpedia.org/ontology/Museum",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Restaurant": {
+        "class_": "http://dbpedia.org/ontology/Restaurant",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ShoppingMall": {
+        "class_": "http://dbpedia.org/ontology/ShoppingMall",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Venue": {
+        "class_": "http://dbpedia.org/ontology/Venue",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [
+            "http://dbpedia.org/ontology/Stadium",
+            "http://dbpedia.org/ontology/Cinema",
+            "http://dbpedia.org/ontology/Theatre"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Casino": {
+        "class_": "http://dbpedia.org/ontology/Casino",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Factory": {
+        "class_": "http://dbpedia.org/ontology/Factory",
+        "parentClass": "http://dbpedia.org/ontology/Building",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Capital": {
+        "class_": "http://dbpedia.org/ontology/Capital",
+        "parentClass": "http://dbpedia.org/ontology/City",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/CapitalOfRegion": {
+        "class_": "http://dbpedia.org/ontology/CapitalOfRegion",
+        "parentClass": "http://dbpedia.org/ontology/City",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/ComicStrip": {
+        "class_": "http://dbpedia.org/ontology/ComicStrip",
+        "parentClass": "http://dbpedia.org/ontology/Comic",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Manga": {
+        "class_": "http://dbpedia.org/ontology/Manga",
+        "parentClass": "http://dbpedia.org/ontology/Comic",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Manhua": {
+        "class_": "http://dbpedia.org/ontology/Manhua",
+        "parentClass": "http://dbpedia.org/ontology/Comic",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Manhwa": {
+        "class_": "http://dbpedia.org/ontology/Manhwa",
+        "parentClass": "http://dbpedia.org/ontology/Comic",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/AnimangaCharacter": {
+        "class_": "http://dbpedia.org/ontology/AnimangaCharacter",
+        "parentClass": "http://dbpedia.org/ontology/ComicsCharacter",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Murderer": {
+        "class_": "http://dbpedia.org/ontology/Murderer",
+        "parentClass": "http://dbpedia.org/ontology/Criminal",
+        "children": [
+            "http://dbpedia.org/ontology/SerialKiller"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Battery": {
+        "class_": "http://dbpedia.org/ontology/Battery",
+        "parentClass": "http://dbpedia.org/ontology/Device",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Engine": {
+        "class_": "http://dbpedia.org/ontology/Engine",
+        "parentClass": "http://dbpedia.org/ontology/Device",
+        "children": [
+            "http://dbpedia.org/ontology/AutomobileEngine",
+            "http://dbpedia.org/ontology/RocketEngine"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/InformationAppliance": {
+        "class_": "http://dbpedia.org/ontology/InformationAppliance",
+        "parentClass": "http://dbpedia.org/ontology/Device",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Weapon": {
+        "class_": "http://dbpedia.org/ontology/Weapon",
+        "parentClass": "http://dbpedia.org/ontology/Device",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Camera": {
+        "class_": "http://dbpedia.org/ontology/Camera",
+        "parentClass": "http://dbpedia.org/ontology/Device",
+        "children": [
+            "http://dbpedia.org/ontology/DigitalCamera"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Instrument": {
+        "class_": "http://dbpedia.org/ontology/Instrument",
+        "parentClass": "http://dbpedia.org/ontology/Device",
+        "children": [
+            "http://dbpedia.org/ontology/Guitar",
+            "http://dbpedia.org/ontology/Organ"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MobilePhone": {
+        "class_": "http://dbpedia.org/ontology/MobilePhone",
+        "parentClass": "http://dbpedia.org/ontology/Device",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Robot": {
+        "class_": "http://dbpedia.org/ontology/Robot",
+        "parentClass": "http://dbpedia.org/ontology/Device",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/CombinationDrug": {
+        "class_": "http://dbpedia.org/ontology/CombinationDrug",
+        "parentClass": "http://dbpedia.org/ontology/Drug",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MonoclonalAntibody": {
+        "class_": "http://dbpedia.org/ontology/MonoclonalAntibody",
+        "parentClass": "http://dbpedia.org/ontology/Drug",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Vaccine": {
+        "class_": "http://dbpedia.org/ontology/Vaccine",
+        "parentClass": "http://dbpedia.org/ontology/Drug",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/VaccinationStatistics": {
+        "class_": "http://dbpedia.org/ontology/VaccinationStatistics",
+        "parentClass": "http://dbpedia.org/ontology/Drug",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/AutomobileEngine": {
+        "class_": "http://dbpedia.org/ontology/AutomobileEngine",
+        "parentClass": "http://dbpedia.org/ontology/Engine",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/RocketEngine": {
+        "class_": "http://dbpedia.org/ontology/RocketEngine",
+        "parentClass": "http://dbpedia.org/ontology/Engine",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/NaturalEvent": {
+        "class_": "http://dbpedia.org/ontology/NaturalEvent",
+        "parentClass": "http://dbpedia.org/ontology/Event",
+        "children": [
+            "http://dbpedia.org/ontology/SolarEclipse",
+            "http://dbpedia.org/ontology/Earthquake",
+            "http://dbpedia.org/ontology/StormSurge"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/SocietalEvent": {
+        "class_": "http://dbpedia.org/ontology/SocietalEvent",
+        "parentClass": "http://dbpedia.org/ontology/Event",
+        "children": [
+            "http://dbpedia.org/ontology/MusicFestival",
+            "http://dbpedia.org/ontology/AcademicConference",
+            "http://dbpedia.org/ontology/HistoricalEvent",
+            "http://dbpedia.org/ontology/Convention",
+            "http://dbpedia.org/ontology/Election",
+            "http://dbpedia.org/ontology/FilmFestival",
+            "http://dbpedia.org/ontology/MilitaryConflict",
+            "http://dbpedia.org/ontology/SpaceMission",
+            "http://dbpedia.org/ontology/SportsEvent",
+            "http://dbpedia.org/ontology/Attack",
+            "http://dbpedia.org/ontology/Meeting",
+            "http://dbpedia.org/ontology/Rebellion"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Outbreak": {
+        "class_": "http://dbpedia.org/ontology/Outbreak",
+        "parentClass": "http://dbpedia.org/ontology/Event",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Competition": {
+        "class_": "http://dbpedia.org/ontology/Competition",
+        "parentClass": "http://dbpedia.org/ontology/Event",
+        "children": [
+            "http://dbpedia.org/ontology/Contest"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/LifeCycleEvent": {
+        "class_": "http://dbpedia.org/ontology/LifeCycleEvent",
+        "parentClass": "http://dbpedia.org/ontology/Event",
+        "children": [
+            "http://dbpedia.org/ontology/PersonalEvent"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/PenaltyShootOut": {
+        "class_": "http://dbpedia.org/ontology/PenaltyShootOut",
+        "parentClass": "http://dbpedia.org/ontology/Event",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Cheese": {
+        "class_": "http://dbpedia.org/ontology/Cheese",
+        "parentClass": "http://dbpedia.org/ontology/Food",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Beverage": {
+        "class_": "http://dbpedia.org/ontology/Beverage",
+        "parentClass": "http://dbpedia.org/ontology/Food",
+        "children": [
+            "http://dbpedia.org/ontology/Beer",
+            "http://dbpedia.org/ontology/Vodka",
+            "http://dbpedia.org/ontology/Wine"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/NationalFootballLeagueSeason": {
+        "class_": "http://dbpedia.org/ontology/NationalFootballLeagueSeason",
+        "parentClass": "http://dbpedia.org/ontology/FootballLeagueSeason",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/BoardGame": {
+        "class_": "http://dbpedia.org/ontology/BoardGame",
+        "parentClass": "http://dbpedia.org/ontology/Game",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/CardGame": {
+        "class_": "http://dbpedia.org/ontology/CardGame",
+        "parentClass": "http://dbpedia.org/ontology/Game",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/GovernmentCabinet": {
+        "class_": "http://dbpedia.org/ontology/GovernmentCabinet",
+        "parentClass": "http://dbpedia.org/ontology/GovernmentAgency",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Fort": {
+        "class_": "http://dbpedia.org/ontology/Fort",
+        "parentClass": "http://dbpedia.org/ontology/MilitaryStructure",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/GraveMonument": {
+        "class_": "http://dbpedia.org/ontology/GraveMonument",
+        "parentClass": "http://dbpedia.org/ontology/Monument",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Memorial": {
+        "class_": "http://dbpedia.org/ontology/Memorial",
+        "parentClass": "http://dbpedia.org/ontology/Monument",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ClassicalMusicArtist": {
+        "class_": "http://dbpedia.org/ontology/ClassicalMusicArtist",
+        "parentClass": "http://dbpedia.org/ontology/MusicalArtist",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Instrumentalist": {
+        "class_": "http://dbpedia.org/ontology/Instrumentalist",
+        "parentClass": "http://dbpedia.org/ontology/MusicalArtist",
+        "children": [
+            "http://dbpedia.org/ontology/Guitarist"
+        ],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/BackScene": {
+        "class_": "http://dbpedia.org/ontology/BackScene",
+        "parentClass": "http://dbpedia.org/ontology/MusicalArtist",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/MusicDirector": {
+        "class_": "http://dbpedia.org/ontology/MusicDirector",
+        "parentClass": "http://dbpedia.org/ontology/MusicalArtist",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/Singer": {
+        "class_": "http://dbpedia.org/ontology/Singer",
+        "parentClass": "http://dbpedia.org/ontology/MusicalArtist",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/OlympicEvent": {
+        "class_": "http://dbpedia.org/ontology/OlympicEvent",
+        "parentClass": "http://dbpedia.org/ontology/Olympics",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/Company": {
+        "class_": "http://dbpedia.org/ontology/Company",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/Publisher",
+            "http://dbpedia.org/ontology/Brewery",
+            "http://dbpedia.org/ontology/LawFirm",
+            "http://dbpedia.org/ontology/PublicTransitSystem",
+            "http://dbpedia.org/ontology/Winery",
+            "http://dbpedia.org/ontology/Bank",
+            "http://dbpedia.org/ontology/RecordLabel",
+            "http://dbpedia.org/ontology/Caterer"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SportsLeague": {
+        "class_": "http://dbpedia.org/ontology/SportsLeague",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/AmericanFootballLeague",
+            "http://dbpedia.org/ontology/VolleyballLeague",
+            "http://dbpedia.org/ontology/BaseballLeague",
+            "http://dbpedia.org/ontology/CanadianFootballLeague",
+            "http://dbpedia.org/ontology/GolfLeague",
+            "http://dbpedia.org/ontology/CurlingLeague",
+            "http://dbpedia.org/ontology/AustralianFootballLeague",
+            "http://dbpedia.org/ontology/AutoRacingLeague",
+            "http://dbpedia.org/ontology/MixedMartialArtsLeague",
+            "http://dbpedia.org/ontology/MotorcycleRacingLeague",
+            "http://dbpedia.org/ontology/PoloLeague",
+            "http://dbpedia.org/ontology/HandballLeague",
+            "http://dbpedia.org/ontology/IceHockeyLeague",
+            "http://dbpedia.org/ontology/BoxingLeague",
+            "http://dbpedia.org/ontology/BowlingLeague",
+            "http://dbpedia.org/ontology/RugbyLeague",
+            "http://dbpedia.org/ontology/SoccerLeague",
+            "http://dbpedia.org/ontology/VideogamesLeague",
+            "http://dbpedia.org/ontology/InlineHockeyLeague",
+            "http://dbpedia.org/ontology/FieldHockeyLeague",
+            "http://dbpedia.org/ontology/CricketLeague",
+            "http://dbpedia.org/ontology/LacrosseLeague",
+            "http://dbpedia.org/ontology/SpeedwayLeague",
+            "http://dbpedia.org/ontology/SoftballLeague",
+            "http://dbpedia.org/ontology/TennisLeague",
+            "http://dbpedia.org/ontology/CyclingLeague",
+            "http://dbpedia.org/ontology/FormulaOneRacing",
+            "http://dbpedia.org/ontology/PaintballLeague",
+            "http://dbpedia.org/ontology/RadioControlledRacingLeague"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/EducationalInstitution": {
+        "class_": "http://dbpedia.org/ontology/EducationalInstitution",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/School",
+            "http://dbpedia.org/ontology/College",
+            "http://dbpedia.org/ontology/University",
+            "http://dbpedia.org/ontology/Library"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SportsClub": {
+        "class_": "http://dbpedia.org/ontology/SportsClub",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/RugbyClub",
+            "http://dbpedia.org/ontology/SoccerClub",
+            "http://dbpedia.org/ontology/HockeyClub"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Broadcaster": {
+        "class_": "http://dbpedia.org/ontology/Broadcaster",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/BroadcastNetwork",
+            "http://dbpedia.org/ontology/RadioStation",
+            "http://dbpedia.org/ontology/TelevisionStation"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Group": {
+        "class_": "http://dbpedia.org/ontology/Group",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/Band",
+            "http://dbpedia.org/ontology/ComedyGroup"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/GovernmentAgency": {
+        "class_": "http://dbpedia.org/ontology/GovernmentAgency",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/GovernmentCabinet"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Legislature": {
+        "class_": "http://dbpedia.org/ontology/Legislature",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MilitaryUnit": {
+        "class_": "http://dbpedia.org/ontology/MilitaryUnit",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/PoliticalParty": {
+        "class_": "http://dbpedia.org/ontology/PoliticalParty",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SportsTeam": {
+        "class_": "http://dbpedia.org/ontology/SportsTeam",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/CricketTeam",
+            "http://dbpedia.org/ontology/SpeedwayTeam",
+            "http://dbpedia.org/ontology/FormulaOneTeam",
+            "http://dbpedia.org/ontology/HandballTeam",
+            "http://dbpedia.org/ontology/BasketballTeam",
+            "http://dbpedia.org/ontology/CyclingTeam",
+            "http://dbpedia.org/ontology/HockeyTeam",
+            "http://dbpedia.org/ontology/AustralianFootballTeam",
+            "http://dbpedia.org/ontology/AmericanFootballTeam",
+            "http://dbpedia.org/ontology/BaseballTeam",
+            "http://dbpedia.org/ontology/CanadianFootballTeam"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/TradeUnion": {
+        "class_": "http://dbpedia.org/ontology/TradeUnion",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Non-ProfitOrganisation": {
+        "class_": "http://dbpedia.org/ontology/Non-ProfitOrganisation",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/RecordOffice"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/EmployersOrganisation": {
+        "class_": "http://dbpedia.org/ontology/EmployersOrganisation",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/GeopoliticalOrganisation": {
+        "class_": "http://dbpedia.org/ontology/GeopoliticalOrganisation",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/InternationalOrganisation": {
+        "class_": "http://dbpedia.org/ontology/InternationalOrganisation",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Parliament": {
+        "class_": "http://dbpedia.org/ontology/Parliament",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ReligiousOrganisation": {
+        "class_": "http://dbpedia.org/ontology/ReligiousOrganisation",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [
+            "http://dbpedia.org/ontology/ClericalOrder"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SambaSchool": {
+        "class_": "http://dbpedia.org/ontology/SambaSchool",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/TermOfOffice": {
+        "class_": "http://dbpedia.org/ontology/TermOfOffice",
+        "parentClass": "http://dbpedia.org/ontology/Organisation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/PoliticalFunction": {
+        "class_": "http://dbpedia.org/ontology/PoliticalFunction",
+        "parentClass": "http://dbpedia.org/ontology/PersonFunction",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Profession": {
+        "class_": "http://dbpedia.org/ontology/Profession",
+        "parentClass": "http://dbpedia.org/ontology/PersonFunction",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Gnetophytes": {
+        "class_": "http://dbpedia.org/ontology/Gnetophytes",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Ginkgo": {
+        "class_": "http://dbpedia.org/ontology/Ginkgo",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Conifer": {
+        "class_": "http://dbpedia.org/ontology/Conifer",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/GreenAlga": {
+        "class_": "http://dbpedia.org/ontology/GreenAlga",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Cycad": {
+        "class_": "http://dbpedia.org/ontology/Cycad",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/FloweringPlant": {
+        "class_": "http://dbpedia.org/ontology/FloweringPlant",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [
+            "http://dbpedia.org/ontology/Grape"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/ClubMoss": {
+        "class_": "http://dbpedia.org/ontology/ClubMoss",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CultivatedVariety": {
+        "class_": "http://dbpedia.org/ontology/CultivatedVariety",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Moss": {
+        "class_": "http://dbpedia.org/ontology/Moss",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Fern": {
+        "class_": "http://dbpedia.org/ontology/Fern",
+        "parentClass": "http://dbpedia.org/ontology/Plant",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Congressman": {
+        "class_": "http://dbpedia.org/ontology/Congressman",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Governor": {
+        "class_": "http://dbpedia.org/ontology/Governor",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Mayor": {
+        "class_": "http://dbpedia.org/ontology/Mayor",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/MemberOfParliament": {
+        "class_": "http://dbpedia.org/ontology/MemberOfParliament",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/President": {
+        "class_": "http://dbpedia.org/ontology/President",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Senator": {
+        "class_": "http://dbpedia.org/ontology/Senator",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Ambassador": {
+        "class_": "http://dbpedia.org/ontology/Ambassador",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/PrimeMinister": {
+        "class_": "http://dbpedia.org/ontology/PrimeMinister",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Chancellor": {
+        "class_": "http://dbpedia.org/ontology/Chancellor",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Deputy": {
+        "class_": "http://dbpedia.org/ontology/Deputy",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Lieutenant": {
+        "class_": "http://dbpedia.org/ontology/Lieutenant",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Minister": {
+        "class_": "http://dbpedia.org/ontology/Minister",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/VicePresident": {
+        "class_": "http://dbpedia.org/ontology/VicePresident",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/VicePrimeMinister": {
+        "class_": "http://dbpedia.org/ontology/VicePrimeMinister",
+        "parentClass": "http://dbpedia.org/ontology/Politician",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/NuclearPowerStation": {
+        "class_": "http://dbpedia.org/ontology/NuclearPowerStation",
+        "parentClass": "http://dbpedia.org/ontology/PowerStation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/NascarDriver": {
+        "class_": "http://dbpedia.org/ontology/NascarDriver",
+        "parentClass": "http://dbpedia.org/ontology/RacingDriver",
+        "children": [],
+        "depth": 8
+    },
+    "http://dbpedia.org/ontology/FormulaOneRacer": {
+        "class_": "http://dbpedia.org/ontology/FormulaOneRacer",
+        "parentClass": "http://dbpedia.org/ontology/RacingDriver",
+        "children": [],
+        "depth": 8
+    },
+    "http://dbpedia.org/ontology/DTMRacer": {
+        "class_": "http://dbpedia.org/ontology/DTMRacer",
+        "parentClass": "http://dbpedia.org/ontology/RacingDriver",
+        "children": [],
+        "depth": 8
+    },
+    "http://dbpedia.org/ontology/RallyDriver": {
+        "class_": "http://dbpedia.org/ontology/RallyDriver",
+        "parentClass": "http://dbpedia.org/ontology/RacingDriver",
+        "children": [],
+        "depth": 8
+    },
+    "http://dbpedia.org/ontology/LatterDaySaint": {
+        "class_": "http://dbpedia.org/ontology/LatterDaySaint",
+        "parentClass": "http://dbpedia.org/ontology/Religious",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/JewishLeader": {
+        "class_": "http://dbpedia.org/ontology/JewishLeader",
+        "parentClass": "http://dbpedia.org/ontology/Religious",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Rebbe": {
+        "class_": "http://dbpedia.org/ontology/Rebbe",
+        "parentClass": "http://dbpedia.org/ontology/Religious",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Pretender": {
+        "class_": "http://dbpedia.org/ontology/Pretender",
+        "parentClass": "http://dbpedia.org/ontology/Royalty",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/BritishRoyalty": {
+        "class_": "http://dbpedia.org/ontology/BritishRoyalty",
+        "parentClass": "http://dbpedia.org/ontology/Royalty",
+        "children": [
+            "http://dbpedia.org/ontology/Baronet"
+        ],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Pharaoh": {
+        "class_": "http://dbpedia.org/ontology/Pharaoh",
+        "parentClass": "http://dbpedia.org/ontology/Royalty",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/City": {
+        "class_": "http://dbpedia.org/ontology/City",
+        "parentClass": "http://dbpedia.org/ontology/Settlement",
+        "children": [
+            "http://dbpedia.org/ontology/Capital",
+            "http://dbpedia.org/ontology/CapitalOfRegion"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CityDistrict": {
+        "class_": "http://dbpedia.org/ontology/CityDistrict",
+        "parentClass": "http://dbpedia.org/ontology/Settlement",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Town": {
+        "class_": "http://dbpedia.org/ontology/Town",
+        "parentClass": "http://dbpedia.org/ontology/Settlement",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Village": {
+        "class_": "http://dbpedia.org/ontology/Village",
+        "parentClass": "http://dbpedia.org/ontology/Settlement",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/HistoricalSettlement": {
+        "class_": "http://dbpedia.org/ontology/HistoricalSettlement",
+        "parentClass": "http://dbpedia.org/ontology/Settlement",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/NationalSoccerClub": {
+        "class_": "http://dbpedia.org/ontology/NationalSoccerClub",
+        "parentClass": "http://dbpedia.org/ontology/SoccerClub",
+        "children": [],
+        "depth": 5
+    },
+    "http://dbpedia.org/ontology/EurovisionSongContestEntry": {
+        "class_": "http://dbpedia.org/ontology/EurovisionSongContestEntry",
+        "parentClass": "http://dbpedia.org/ontology/Song",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/NationalFootballLeagueEvent": {
+        "class_": "http://dbpedia.org/ontology/NationalFootballLeagueEvent",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Race": {
+        "class_": "http://dbpedia.org/ontology/Race",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [
+            "http://dbpedia.org/ontology/CyclingRace",
+            "http://dbpedia.org/ontology/HorseRace",
+            "http://dbpedia.org/ontology/MotorRace"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Tournament": {
+        "class_": "http://dbpedia.org/ontology/Tournament",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [
+            "http://dbpedia.org/ontology/GolfTournament",
+            "http://dbpedia.org/ontology/SoccerTournament",
+            "http://dbpedia.org/ontology/TennisTournament",
+            "http://dbpedia.org/ontology/WomensTennisAssociationTournament"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/FootballMatch": {
+        "class_": "http://dbpedia.org/ontology/FootballMatch",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/GrandPrix": {
+        "class_": "http://dbpedia.org/ontology/GrandPrix",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/MixedMartialArtsEvent": {
+        "class_": "http://dbpedia.org/ontology/MixedMartialArtsEvent",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Olympics": {
+        "class_": "http://dbpedia.org/ontology/Olympics",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [
+            "http://dbpedia.org/ontology/OlympicEvent"
+        ],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/WrestlingEvent": {
+        "class_": "http://dbpedia.org/ontology/WrestlingEvent",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CyclingCompetition": {
+        "class_": "http://dbpedia.org/ontology/CyclingCompetition",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/InternationalFootballLeagueEvent": {
+        "class_": "http://dbpedia.org/ontology/InternationalFootballLeagueEvent",
+        "parentClass": "http://dbpedia.org/ontology/SportsEvent",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/SportsTeamSeason": {
+        "class_": "http://dbpedia.org/ontology/SportsTeamSeason",
+        "parentClass": "http://dbpedia.org/ontology/SportsSeason",
+        "children": [
+            "http://dbpedia.org/ontology/BaseballSeason",
+            "http://dbpedia.org/ontology/FootballLeagueSeason",
+            "http://dbpedia.org/ontology/NCAATeamSeason",
+            "http://dbpedia.org/ontology/SoccerClubSeason",
+            "http://dbpedia.org/ontology/SoccerLeagueSeason"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MotorsportSeason": {
+        "class_": "http://dbpedia.org/ontology/MotorsportSeason",
+        "parentClass": "http://dbpedia.org/ontology/SportsSeason",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/CricketTeam": {
+        "class_": "http://dbpedia.org/ontology/CricketTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/SpeedwayTeam": {
+        "class_": "http://dbpedia.org/ontology/SpeedwayTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/FormulaOneTeam": {
+        "class_": "http://dbpedia.org/ontology/FormulaOneTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/HandballTeam": {
+        "class_": "http://dbpedia.org/ontology/HandballTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/BasketballTeam": {
+        "class_": "http://dbpedia.org/ontology/BasketballTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CyclingTeam": {
+        "class_": "http://dbpedia.org/ontology/CyclingTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/HockeyTeam": {
+        "class_": "http://dbpedia.org/ontology/HockeyTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/AustralianFootballTeam": {
+        "class_": "http://dbpedia.org/ontology/AustralianFootballTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/AmericanFootballTeam": {
+        "class_": "http://dbpedia.org/ontology/AmericanFootballTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/BaseballTeam": {
+        "class_": "http://dbpedia.org/ontology/BaseballTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/CanadianFootballTeam": {
+        "class_": "http://dbpedia.org/ontology/CanadianFootballTeam",
+        "parentClass": "http://dbpedia.org/ontology/SportsTeam",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/BrownDwarf": {
+        "class_": "http://dbpedia.org/ontology/BrownDwarf",
+        "parentClass": "http://dbpedia.org/ontology/Star",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RailwayStation": {
+        "class_": "http://dbpedia.org/ontology/RailwayStation",
+        "parentClass": "http://dbpedia.org/ontology/Station",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/MetroStation": {
+        "class_": "http://dbpedia.org/ontology/MetroStation",
+        "parentClass": "http://dbpedia.org/ontology/Station",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/RouteStop": {
+        "class_": "http://dbpedia.org/ontology/RouteStop",
+        "parentClass": "http://dbpedia.org/ontology/Station",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/TramStation": {
+        "class_": "http://dbpedia.org/ontology/TramStation",
+        "parentClass": "http://dbpedia.org/ontology/Station",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Stadium": {
+        "class_": "http://dbpedia.org/ontology/Stadium",
+        "parentClass": "http://dbpedia.org/ontology/Venue",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Cinema": {
+        "class_": "http://dbpedia.org/ontology/Cinema",
+        "parentClass": "http://dbpedia.org/ontology/Venue",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Theatre": {
+        "class_": "http://dbpedia.org/ontology/Theatre",
+        "parentClass": "http://dbpedia.org/ontology/Venue",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Historian": {
+        "class_": "http://dbpedia.org/ontology/Historian",
+        "parentClass": "http://dbpedia.org/ontology/Writer",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Poet": {
+        "class_": "http://dbpedia.org/ontology/Poet",
+        "parentClass": "http://dbpedia.org/ontology/Writer",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/ScreenWriter": {
+        "class_": "http://dbpedia.org/ontology/ScreenWriter",
+        "parentClass": "http://dbpedia.org/ontology/Writer",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/MusicComposer": {
+        "class_": "http://dbpedia.org/ontology/MusicComposer",
+        "parentClass": "http://dbpedia.org/ontology/Writer",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/PlayWright": {
+        "class_": "http://dbpedia.org/ontology/PlayWright",
+        "parentClass": "http://dbpedia.org/ontology/Writer",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/SongWriter": {
+        "class_": "http://dbpedia.org/ontology/SongWriter",
+        "parentClass": "http://dbpedia.org/ontology/Writer",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/Poem": {
+        "class_": "http://dbpedia.org/ontology/Poem",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/PeriodicalLiterature": {
+        "class_": "http://dbpedia.org/ontology/PeriodicalLiterature",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [
+            "http://dbpedia.org/ontology/AcademicJournal",
+            "http://dbpedia.org/ontology/Magazine",
+            "http://dbpedia.org/ontology/Newspaper",
+            "http://dbpedia.org/ontology/UndergroundJournal"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Book": {
+        "class_": "http://dbpedia.org/ontology/Book",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [
+            "http://dbpedia.org/ontology/Novel"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Comic": {
+        "class_": "http://dbpedia.org/ontology/Comic",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [
+            "http://dbpedia.org/ontology/ComicStrip",
+            "http://dbpedia.org/ontology/Manga",
+            "http://dbpedia.org/ontology/Manhua",
+            "http://dbpedia.org/ontology/Manhwa"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Play": {
+        "class_": "http://dbpedia.org/ontology/Play",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Annotation": {
+        "class_": "http://dbpedia.org/ontology/Annotation",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [
+            "http://dbpedia.org/ontology/Reference"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Article": {
+        "class_": "http://dbpedia.org/ontology/Article",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Drama": {
+        "class_": "http://dbpedia.org/ontology/Drama",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Law": {
+        "class_": "http://dbpedia.org/ontology/Law",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Letter": {
+        "class_": "http://dbpedia.org/ontology/Letter",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MultiVolumePublication": {
+        "class_": "http://dbpedia.org/ontology/MultiVolumePublication",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Quote": {
+        "class_": "http://dbpedia.org/ontology/Quote",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Resume": {
+        "class_": "http://dbpedia.org/ontology/Resume",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/StatedResolution": {
+        "class_": "http://dbpedia.org/ontology/StatedResolution",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Treaty": {
+        "class_": "http://dbpedia.org/ontology/Treaty",
+        "parentClass": "http://dbpedia.org/ontology/WrittenWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Single": {
+        "class_": "http://dbpedia.org/ontology/Single",
+        "parentClass": "http://dbpedia.org/ontology/MusicalWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Album": {
+        "class_": "http://dbpedia.org/ontology/Album",
+        "parentClass": "http://dbpedia.org/ontology/MusicalWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ArtistDiscography": {
+        "class_": "http://dbpedia.org/ontology/ArtistDiscography",
+        "parentClass": "http://dbpedia.org/ontology/MusicalWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/ClassicalMusicComposition": {
+        "class_": "http://dbpedia.org/ontology/ClassicalMusicComposition",
+        "parentClass": "http://dbpedia.org/ontology/MusicalWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Musical": {
+        "class_": "http://dbpedia.org/ontology/Musical",
+        "parentClass": "http://dbpedia.org/ontology/MusicalWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Song": {
+        "class_": "http://dbpedia.org/ontology/Song",
+        "parentClass": "http://dbpedia.org/ontology/MusicalWork",
+        "children": [
+            "http://dbpedia.org/ontology/EurovisionSongContestEntry"
+        ],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/NationalAnthem": {
+        "class_": "http://dbpedia.org/ontology/NationalAnthem",
+        "parentClass": "http://dbpedia.org/ontology/MusicalWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Opera": {
+        "class_": "http://dbpedia.org/ontology/Opera",
+        "parentClass": "http://dbpedia.org/ontology/MusicalWork",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/CareerStation": {
+        "class_": "http://dbpedia.org/ontology/CareerStation",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [
+            "http://dbpedia.org/ontology/MilitaryService"
+        ],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Tenure": {
+        "class_": "http://dbpedia.org/ontology/Tenure",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Year": {
+        "class_": "http://dbpedia.org/ontology/Year",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/YearInSpaceflight": {
+        "class_": "http://dbpedia.org/ontology/YearInSpaceflight",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/GeologicalPeriod": {
+        "class_": "http://dbpedia.org/ontology/GeologicalPeriod",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/HistoricalPeriod": {
+        "class_": "http://dbpedia.org/ontology/HistoricalPeriod",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/PeriodOfArtisticStyle": {
+        "class_": "http://dbpedia.org/ontology/PeriodOfArtisticStyle",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/PrehistoricalPeriod": {
+        "class_": "http://dbpedia.org/ontology/PrehistoricalPeriod",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/ProtohistoricalPeriod": {
+        "class_": "http://dbpedia.org/ontology/ProtohistoricalPeriod",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Reign": {
+        "class_": "http://dbpedia.org/ontology/Reign",
+        "parentClass": "http://dbpedia.org/ontology/TimePeriod",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Diocese": {
+        "class_": "http://dbpedia.org/ontology/Diocese",
+        "parentClass": "http://dbpedia.org/ontology/ClericalAdministrativeRegion",
+        "children": []
+    },
+    "http://dbpedia.org/ontology/Deanery": {
+        "class_": "http://dbpedia.org/ontology/Deanery",
+        "parentClass": "http://dbpedia.org/ontology/ClericalAdministrativeRegion",
+        "children": []
+    },
+    "http://dbpedia.org/ontology/Parish": {
+        "class_": "http://dbpedia.org/ontology/Parish",
+        "parentClass": "http://dbpedia.org/ontology/ClericalAdministrativeRegion",
+        "children": []
+    },
+    "http://dbpedia.org/ontology/ClericalAdministrativeRegion": {
+        "class_": "http://dbpedia.org/ontology/ClericalAdministrativeRegion",
+        "parentClass": "http://dbpedia.org/ontology/انتظامی_علاقہ",
+        "children": [
+            "http://dbpedia.org/ontology/Diocese",
+            "http://dbpedia.org/ontology/Deanery",
+            "http://dbpedia.org/ontology/Parish"
+        ]
+    },
+    "http://dbpedia.org/ontology/RecordOffice": {
+        "class_": "http://dbpedia.org/ontology/RecordOffice",
+        "parentClass": "http://dbpedia.org/ontology/Non-ProfitOrganisation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Reference": {
+        "class_": "http://dbpedia.org/ontology/Reference",
+        "parentClass": "http://dbpedia.org/ontology/Annotation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/DigitalCamera": {
+        "class_": "http://dbpedia.org/ontology/DigitalCamera",
+        "parentClass": "http://dbpedia.org/ontology/Camera",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Contest": {
+        "class_": "http://dbpedia.org/ontology/Contest",
+        "parentClass": "http://dbpedia.org/ontology/Competition",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/HistoricalDistrict": {
+        "class_": "http://dbpedia.org/ontology/HistoricalDistrict",
+        "parentClass": "http://dbpedia.org/ontology/District",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/NobleFamily": {
+        "class_": "http://dbpedia.org/ontology/NobleFamily",
+        "parentClass": "http://dbpedia.org/ontology/Family",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/HumanGeneLocation": {
+        "class_": "http://dbpedia.org/ontology/HumanGeneLocation",
+        "parentClass": "http://dbpedia.org/ontology/GeneLocation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/MouseGeneLocation": {
+        "class_": "http://dbpedia.org/ontology/MouseGeneLocation",
+        "parentClass": "http://dbpedia.org/ontology/GeneLocation",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Manor": {
+        "class_": "http://dbpedia.org/ontology/Manor",
+        "parentClass": "http://dbpedia.org/ontology/HistoricalAreaOfAuthority",
+        "children": [],
+        "depth": 6
+    },
+    "http://dbpedia.org/ontology/ElectricalSubstation": {
+        "class_": "http://dbpedia.org/ontology/ElectricalSubstation",
+        "parentClass": "http://dbpedia.org/ontology/Infrastucture",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Guitar": {
+        "class_": "http://dbpedia.org/ontology/Guitar",
+        "parentClass": "http://dbpedia.org/ontology/Instrument",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Organ": {
+        "class_": "http://dbpedia.org/ontology/Organ",
+        "parentClass": "http://dbpedia.org/ontology/Instrument",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/PersonalEvent": {
+        "class_": "http://dbpedia.org/ontology/PersonalEvent",
+        "parentClass": "http://dbpedia.org/ontology/LifeCycleEvent",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/TrackList": {
+        "class_": "http://dbpedia.org/ontology/TrackList",
+        "parentClass": "http://dbpedia.org/ontology/List",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/Treadmill": {
+        "class_": "http://dbpedia.org/ontology/Treadmill",
+        "parentClass": "http://dbpedia.org/ontology/Mill",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Watermill": {
+        "class_": "http://dbpedia.org/ontology/Watermill",
+        "parentClass": "http://dbpedia.org/ontology/Mill",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/WindMotor": {
+        "class_": "http://dbpedia.org/ontology/WindMotor",
+        "parentClass": "http://dbpedia.org/ontology/Mill",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Windmill": {
+        "class_": "http://dbpedia.org/ontology/Windmill",
+        "parentClass": "http://dbpedia.org/ontology/Mill",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/CoalPit": {
+        "class_": "http://dbpedia.org/ontology/CoalPit",
+        "parentClass": "http://dbpedia.org/ontology/Mine",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/SerialKiller": {
+        "class_": "http://dbpedia.org/ontology/SerialKiller",
+        "parentClass": "http://dbpedia.org/ontology/Murderer",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/ConveyorSystem": {
+        "class_": "http://dbpedia.org/ontology/ConveyorSystem",
+        "parentClass": "http://dbpedia.org/ontology/On-SiteTransportation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/Escalator": {
+        "class_": "http://dbpedia.org/ontology/Escalator",
+        "parentClass": "http://dbpedia.org/ontology/On-SiteTransportation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/MovingWalkway": {
+        "class_": "http://dbpedia.org/ontology/MovingWalkway",
+        "parentClass": "http://dbpedia.org/ontology/On-SiteTransportation",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/HistoricalProvince": {
+        "class_": "http://dbpedia.org/ontology/HistoricalProvince",
+        "parentClass": "http://dbpedia.org/ontology/Province",
+        "children": [],
+        "depth": 7
+    },
+    "http://dbpedia.org/ontology/ClericalOrder": {
+        "class_": "http://dbpedia.org/ontology/ClericalOrder",
+        "parentClass": "http://dbpedia.org/ontology/ReligiousOrganisation",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/ArtificialSatellite": {
+        "class_": "http://dbpedia.org/ontology/ArtificialSatellite",
+        "parentClass": "http://dbpedia.org/ontology/Satellite",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Globularswarm": {
+        "class_": "http://dbpedia.org/ontology/Globularswarm",
+        "parentClass": "http://dbpedia.org/ontology/Swarm",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Openswarm": {
+        "class_": "http://dbpedia.org/ontology/Openswarm",
+        "parentClass": "http://dbpedia.org/ontology/Swarm",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/OldTerritory": {
+        "class_": "http://dbpedia.org/ontology/OldTerritory",
+        "parentClass": "http://dbpedia.org/ontology/Territory",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/ChristianDoctrine": {
+        "class_": "http://dbpedia.org/ontology/ChristianDoctrine",
+        "parentClass": "http://dbpedia.org/ontology/TheologicalConcept",
+        "children": [],
+        "depth": 3
+    },
+    "http://dbpedia.org/ontology/WikimediaTemplate": {
+        "class_": "http://dbpedia.org/ontology/WikimediaTemplate",
+        "parentClass": "http://dbpedia.org/ontology/Unknown",
+        "children": [],
+        "depth": 2
+    },
+    "http://dbpedia.org/ontology/ControlledDesignationOfOriginWine": {
+        "class_": "http://dbpedia.org/ontology/ControlledDesignationOfOriginWine",
+        "parentClass": "http://dbpedia.org/ontology/Wine",
+        "children": [],
+        "depth": 4
+    },
+    "http://dbpedia.org/ontology/Activity": {
+        "class_": "http://dbpedia.org/ontology/Activity",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Sport",
+            "http://dbpedia.org/ontology/Game",
+            "http://dbpedia.org/ontology/Sales"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Name": {
+        "class_": "http://dbpedia.org/ontology/Name",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Surname",
+            "http://dbpedia.org/ontology/GivenName"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Place": {
+        "class_": "http://dbpedia.org/ontology/Place",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/ConcentrationCamp",
+            "http://dbpedia.org/ontology/SiteOfSpecialScientificInterest",
+            "http://dbpedia.org/ontology/WineRegion",
+            "http://dbpedia.org/ontology/Garden",
+            "http://dbpedia.org/ontology/PopulatedPlace",
+            "http://dbpedia.org/ontology/WorldHeritageSite",
+            "http://dbpedia.org/ontology/CelestialBody",
+            "http://dbpedia.org/ontology/NaturalPlace",
+            "http://dbpedia.org/ontology/HistoricPlace",
+            "http://dbpedia.org/ontology/Park",
+            "http://dbpedia.org/ontology/ProtectedArea",
+            "http://dbpedia.org/ontology/Cemetery",
+            "http://dbpedia.org/ontology/CountrySeat",
+            "http://dbpedia.org/ontology/Mine"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Language": {
+        "class_": "http://dbpedia.org/ontology/Language",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/ProgrammingLanguage"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/ArchitecturalStructure": {
+        "class_": "http://dbpedia.org/ontology/ArchitecturalStructure",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Tunnel",
+            "http://dbpedia.org/ontology/SportFacility",
+            "http://dbpedia.org/ontology/Tower",
+            "http://dbpedia.org/ontology/Infrastructure",
+            "http://dbpedia.org/ontology/AmusementParkAttraction",
+            "http://dbpedia.org/ontology/Building",
+            "http://dbpedia.org/ontology/MilitaryStructure",
+            "http://dbpedia.org/ontology/Monument",
+            "http://dbpedia.org/ontology/Arena",
+            "http://dbpedia.org/ontology/Infrastucture",
+            "http://dbpedia.org/ontology/Mill",
+            "http://dbpedia.org/ontology/Pyramid",
+            "http://dbpedia.org/ontology/Square",
+            "http://dbpedia.org/ontology/Zoo"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Currency": {
+        "class_": "http://dbpedia.org/ontology/Currency",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/AnatomicalStructure": {
+        "class_": "http://dbpedia.org/ontology/AnatomicalStructure",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Embryology",
+            "http://dbpedia.org/ontology/Lymph",
+            "http://dbpedia.org/ontology/Artery",
+            "http://dbpedia.org/ontology/Bone",
+            "http://dbpedia.org/ontology/Brain",
+            "http://dbpedia.org/ontology/Ligament",
+            "http://dbpedia.org/ontology/Muscle",
+            "http://dbpedia.org/ontology/Nerve",
+            "http://dbpedia.org/ontology/Vein",
+            "http://dbpedia.org/ontology/BloodVessel"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Colour": {
+        "class_": "http://dbpedia.org/ontology/Colour",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Species": {
+        "class_": "http://dbpedia.org/ontology/Species",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Archaea",
+            "http://dbpedia.org/ontology/Bacteria",
+            "http://dbpedia.org/ontology/Eukaryote"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/TopicalConcept": {
+        "class_": "http://dbpedia.org/ontology/TopicalConcept",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Genre",
+            "http://dbpedia.org/ontology/Type",
+            "http://dbpedia.org/ontology/Fashion",
+            "http://dbpedia.org/ontology/AcademicSubject",
+            "http://dbpedia.org/ontology/CardinalDirection",
+            "http://dbpedia.org/ontology/Ideology",
+            "http://dbpedia.org/ontology/MathematicalConcept",
+            "http://dbpedia.org/ontology/PhilosophicalConcept",
+            "http://dbpedia.org/ontology/PoliticalConcept",
+            "http://dbpedia.org/ontology/ScientificConcept",
+            "http://dbpedia.org/ontology/Standard",
+            "http://dbpedia.org/ontology/SystemOfLaw",
+            "http://dbpedia.org/ontology/Tax",
+            "http://dbpedia.org/ontology/Taxon",
+            "http://dbpedia.org/ontology/TheologicalConcept"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/MedicalSpecialty": {
+        "class_": "http://dbpedia.org/ontology/MedicalSpecialty",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Biomolecule": {
+        "class_": "http://dbpedia.org/ontology/Biomolecule",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Gene",
+            "http://dbpedia.org/ontology/Enzyme",
+            "http://dbpedia.org/ontology/Protein",
+            "http://dbpedia.org/ontology/Hormone",
+            "http://dbpedia.org/ontology/Lipid",
+            "http://dbpedia.org/ontology/Polysaccharide"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/ChemicalSubstance": {
+        "class_": "http://dbpedia.org/ontology/ChemicalSubstance",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Mineral",
+            "http://dbpedia.org/ontology/ChemicalCompound",
+            "http://dbpedia.org/ontology/Drug",
+            "http://dbpedia.org/ontology/ChemicalElement"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Identifier": {
+        "class_": "http://dbpedia.org/ontology/Identifier",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/TopLevelDomain"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/MeanOfTransportation": {
+        "class_": "http://dbpedia.org/ontology/MeanOfTransportation",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Motorcycle",
+            "http://dbpedia.org/ontology/Rocket",
+            "http://dbpedia.org/ontology/Locomotive",
+            "http://dbpedia.org/ontology/SpaceShuttle",
+            "http://dbpedia.org/ontology/SpaceStation",
+            "http://dbpedia.org/ontology/Aircraft",
+            "http://dbpedia.org/ontology/Automobile",
+            "http://dbpedia.org/ontology/Ship",
+            "http://dbpedia.org/ontology/Train",
+            "http://dbpedia.org/ontology/MilitaryVehicle",
+            "http://dbpedia.org/ontology/On-SiteTransportation",
+            "http://dbpedia.org/ontology/TrainCarriage",
+            "http://dbpedia.org/ontology/Tram",
+            "http://dbpedia.org/ontology/Spacecraft"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/UnitOfWork": {
+        "class_": "http://dbpedia.org/ontology/UnitOfWork",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Project",
+            "http://dbpedia.org/ontology/Case"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Agent": {
+        "class_": "http://dbpedia.org/ontology/Agent",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Deity",
+            "http://dbpedia.org/ontology/FictionalCharacter",
+            "http://dbpedia.org/ontology/Organisation",
+            "http://dbpedia.org/ontology/Employer",
+            "http://dbpedia.org/ontology/Family"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Work": {
+        "class_": "http://dbpedia.org/ontology/Work",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Software",
+            "http://dbpedia.org/ontology/Database",
+            "http://dbpedia.org/ontology/Document",
+            "http://dbpedia.org/ontology/Artwork",
+            "http://dbpedia.org/ontology/Film",
+            "http://dbpedia.org/ontology/RadioProgram",
+            "http://dbpedia.org/ontology/TelevisionEpisode",
+            "http://dbpedia.org/ontology/TelevisionSeason",
+            "http://dbpedia.org/ontology/TelevisionShow",
+            "http://dbpedia.org/ontology/Website",
+            "http://dbpedia.org/ontology/WrittenWork",
+            "http://dbpedia.org/ontology/MusicalWork",
+            "http://dbpedia.org/ontology/CollectionOfValuables",
+            "http://dbpedia.org/ontology/LineOfFashion"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/SportCompetitionResult": {
+        "class_": "http://dbpedia.org/ontology/SportCompetitionResult",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/SnookerWorldRanking",
+            "http://dbpedia.org/ontology/OlympicResult"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Award": {
+        "class_": "http://dbpedia.org/ontology/Award",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Decoration",
+            "http://dbpedia.org/ontology/NobelPrize"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Device": {
+        "class_": "http://dbpedia.org/ontology/Device",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Battery",
+            "http://dbpedia.org/ontology/Engine",
+            "http://dbpedia.org/ontology/InformationAppliance",
+            "http://dbpedia.org/ontology/Weapon",
+            "http://dbpedia.org/ontology/Camera",
+            "http://dbpedia.org/ontology/Instrument",
+            "http://dbpedia.org/ontology/MobilePhone",
+            "http://dbpedia.org/ontology/Robot"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Disease": {
+        "class_": "http://dbpedia.org/ontology/Disease",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/EthnicGroup": {
+        "class_": "http://dbpedia.org/ontology/EthnicGroup",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Event": {
+        "class_": "http://dbpedia.org/ontology/Event",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/NaturalEvent",
+            "http://dbpedia.org/ontology/SocietalEvent",
+            "http://dbpedia.org/ontology/Outbreak",
+            "http://dbpedia.org/ontology/Competition",
+            "http://dbpedia.org/ontology/LifeCycleEvent",
+            "http://dbpedia.org/ontology/PenaltyShootOut"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Food": {
+        "class_": "http://dbpedia.org/ontology/Food",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/Cheese",
+            "http://dbpedia.org/ontology/Beverage"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Pandemic": {
+        "class_": "http://dbpedia.org/ontology/Pandemic",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/PersonFunction": {
+        "class_": "http://dbpedia.org/ontology/PersonFunction",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/PoliticalFunction",
+            "http://dbpedia.org/ontology/Profession"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/SportsSeason": {
+        "class_": "http://dbpedia.org/ontology/SportsSeason",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/SportsTeamSeason",
+            "http://dbpedia.org/ontology/MotorsportSeason"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/TimePeriod": {
+        "class_": "http://dbpedia.org/ontology/TimePeriod",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/CareerStation",
+            "http://dbpedia.org/ontology/Tenure",
+            "http://dbpedia.org/ontology/Year",
+            "http://dbpedia.org/ontology/YearInSpaceflight",
+            "http://dbpedia.org/ontology/GeologicalPeriod",
+            "http://dbpedia.org/ontology/HistoricalPeriod",
+            "http://dbpedia.org/ontology/PeriodOfArtisticStyle",
+            "http://dbpedia.org/ontology/PrehistoricalPeriod",
+            "http://dbpedia.org/ontology/ProtohistoricalPeriod",
+            "http://dbpedia.org/ontology/Reign"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Algorithm": {
+        "class_": "http://dbpedia.org/ontology/Algorithm",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Altitude": {
+        "class_": "http://dbpedia.org/ontology/Altitude",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Area": {
+        "class_": "http://dbpedia.org/ontology/Area",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Blazon": {
+        "class_": "http://dbpedia.org/ontology/Blazon",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Browser": {
+        "class_": "http://dbpedia.org/ontology/Browser",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/ChartsPlacements": {
+        "class_": "http://dbpedia.org/ontology/ChartsPlacements",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Cipher": {
+        "class_": "http://dbpedia.org/ontology/Cipher",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Covid19": {
+        "class_": "http://dbpedia.org/ontology/Covid19",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Demographics": {
+        "class_": "http://dbpedia.org/ontology/Demographics",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Depth": {
+        "class_": "http://dbpedia.org/ontology/Depth",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Diploma": {
+        "class_": "http://dbpedia.org/ontology/Diploma",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/ElectionDiagram": {
+        "class_": "http://dbpedia.org/ontology/ElectionDiagram",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/FileSystem": {
+        "class_": "http://dbpedia.org/ontology/FileSystem",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Flag": {
+        "class_": "http://dbpedia.org/ontology/Flag",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/GeneLocation": {
+        "class_": "http://dbpedia.org/ontology/GeneLocation",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/HumanGeneLocation",
+            "http://dbpedia.org/ontology/MouseGeneLocation"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/GrossDomesticProduct": {
+        "class_": "http://dbpedia.org/ontology/GrossDomesticProduct",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/GrossDomesticProductPerCapita": {
+        "class_": "http://dbpedia.org/ontology/GrossDomesticProductPerCapita",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/HistoricalRegion": {
+        "class_": "http://dbpedia.org/ontology/HistoricalRegion",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/List": {
+        "class_": "http://dbpedia.org/ontology/List",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/TrackList"
+        ],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Media": {
+        "class_": "http://dbpedia.org/ontology/Media",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Medicine": {
+        "class_": "http://dbpedia.org/ontology/Medicine",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Population": {
+        "class_": "http://dbpedia.org/ontology/Population",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Protocol": {
+        "class_": "http://dbpedia.org/ontology/Protocol",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/PublicService": {
+        "class_": "http://dbpedia.org/ontology/PublicService",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Relationship": {
+        "class_": "http://dbpedia.org/ontology/Relationship",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Spreadsheet": {
+        "class_": "http://dbpedia.org/ontology/Spreadsheet",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/StarCluster": {
+        "class_": "http://dbpedia.org/ontology/StarCluster",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Statistic": {
+        "class_": "http://dbpedia.org/ontology/Statistic",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Tank": {
+        "class_": "http://dbpedia.org/ontology/Tank",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [],
+        "depth": 1
+    },
+    "http://dbpedia.org/ontology/Unknown": {
+        "class_": "http://dbpedia.org/ontology/Unknown",
+        "parentClass": "http://www.w3.org/2002/07/owl#Thing",
+        "children": [
+            "http://dbpedia.org/ontology/WikimediaTemplate"
+        ],
+        "depth": 1
+    },
+    "http://www.w3.org/2002/07/owl#Thing": {
+        "class_": "http://www.w3.org/2002/07/owl#Thing",
+        "parentClass": null,
+        "children": [
+            "http://dbpedia.org/ontology/Activity",
+            "http://dbpedia.org/ontology/Name",
+            "http://dbpedia.org/ontology/Place",
+            "http://dbpedia.org/ontology/Language",
+            "http://dbpedia.org/ontology/ArchitecturalStructure",
+            "http://dbpedia.org/ontology/Currency",
+            "http://dbpedia.org/ontology/AnatomicalStructure",
+            "http://dbpedia.org/ontology/Colour",
+            "http://dbpedia.org/ontology/Species",
+            "http://dbpedia.org/ontology/TopicalConcept",
+            "http://dbpedia.org/ontology/MedicalSpecialty",
+            "http://dbpedia.org/ontology/Biomolecule",
+            "http://dbpedia.org/ontology/ChemicalSubstance",
+            "http://dbpedia.org/ontology/Identifier",
+            "http://dbpedia.org/ontology/MeanOfTransportation",
+            "http://dbpedia.org/ontology/UnitOfWork",
+            "http://dbpedia.org/ontology/Agent",
+            "http://dbpedia.org/ontology/Work",
+            "http://dbpedia.org/ontology/SportCompetitionResult",
+            "http://dbpedia.org/ontology/Award",
+            "http://dbpedia.org/ontology/Device",
+            "http://dbpedia.org/ontology/Disease",
+            "http://dbpedia.org/ontology/EthnicGroup",
+            "http://dbpedia.org/ontology/Event",
+            "http://dbpedia.org/ontology/Food",
+            "http://dbpedia.org/ontology/Pandemic",
+            "http://dbpedia.org/ontology/PersonFunction",
+            "http://dbpedia.org/ontology/SportsSeason",
+            "http://dbpedia.org/ontology/TimePeriod",
+            "http://dbpedia.org/ontology/Algorithm",
+            "http://dbpedia.org/ontology/Altitude",
+            "http://dbpedia.org/ontology/Area",
+            "http://dbpedia.org/ontology/Blazon",
+            "http://dbpedia.org/ontology/Browser",
+            "http://dbpedia.org/ontology/ChartsPlacements",
+            "http://dbpedia.org/ontology/Cipher",
+            "http://dbpedia.org/ontology/Covid19",
+            "http://dbpedia.org/ontology/Demographics",
+            "http://dbpedia.org/ontology/Depth",
+            "http://dbpedia.org/ontology/Diploma",
+            "http://dbpedia.org/ontology/ElectionDiagram",
+            "http://dbpedia.org/ontology/FileSystem",
+            "http://dbpedia.org/ontology/Flag",
+            "http://dbpedia.org/ontology/GeneLocation",
+            "http://dbpedia.org/ontology/GrossDomesticProduct",
+            "http://dbpedia.org/ontology/GrossDomesticProductPerCapita",
+            "http://dbpedia.org/ontology/HistoricalRegion",
+            "http://dbpedia.org/ontology/List",
+            "http://dbpedia.org/ontology/Media",
+            "http://dbpedia.org/ontology/Medicine",
+            "http://dbpedia.org/ontology/Population",
+            "http://dbpedia.org/ontology/Protocol",
+            "http://dbpedia.org/ontology/PublicService",
+            "http://dbpedia.org/ontology/Relationship",
+            "http://dbpedia.org/ontology/Spreadsheet",
+            "http://dbpedia.org/ontology/StarCluster",
+            "http://dbpedia.org/ontology/Statistic",
+            "http://dbpedia.org/ontology/Tank",
+            "http://dbpedia.org/ontology/Unknown"
+        ],
+        "depth": 0
+    }
+}

--- a/data/vocabularies/owl.ttl
+++ b/data/vocabularies/owl.ttl
@@ -1,0 +1,552 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix grddl: <http://www.w3.org/2003/g/data-view#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://www.w3.org/2002/07/owl> a owl:Ontology ;
+     dc:title "The OWL 2 Schema vocabulary (OWL 2)" ;
+     rdfs:comment """
+  This ontology partially describes the built-in classes and
+  properties that together form the basis of the RDF/XML syntax of OWL 2.
+  The content of this ontology is based on Tables 6.1 and 6.2
+  in Section 6.4 of the OWL 2 RDF-Based Semantics specification,
+  available at http://www.w3.org/TR/owl2-rdf-based-semantics/.
+  Please note that those tables do not include the different annotations
+  (labels, comments and rdfs:isDefinedBy links) used in this file.
+  Also note that the descriptions provided in this ontology do not
+  provide a complete and correct formal description of either the syntax
+  or the semantics of the introduced terms (please see the OWL 2
+  recommendations for the complete and normative specifications).
+  Furthermore, the information provided by this ontology may be
+  misleading if not used with care. This ontology SHOULD NOT be imported
+  into OWL ontologies. Importing this file into an OWL 2 DL ontology
+  will cause it to become an OWL 2 Full ontology and may have other,
+  unexpected, consequences.
+   """ ;
+     rdfs:isDefinedBy
+          <http://www.w3.org/TR/owl2-mapping-to-rdf/>,
+          <http://www.w3.org/TR/owl2-rdf-based-semantics/>,
+          <http://www.w3.org/TR/owl2-syntax/> ;
+     rdfs:seeAlso   <http://www.w3.org/TR/owl2-rdf-based-semantics/#table-axiomatic-classes>,
+                    <http://www.w3.org/TR/owl2-rdf-based-semantics/#table-axiomatic-properties> ;
+     owl:imports <http://www.w3.org/2000/01/rdf-schema> ;
+     owl:versionIRI <http://www.w3.org/2002/07/owl> ;
+     owl:versionInfo "$Date: 2009/11/15 10:54:12 $" ;
+     grddl:namespaceTransformation <http://dev.w3.org/cvsweb/2009/owl-grddl/owx2rdf.xsl> . 
+
+
+owl:AllDifferent a rdfs:Class ;
+     rdfs:label "AllDifferent" ;
+     rdfs:comment "The class of collections of pairwise different individuals." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Resource . 
+
+owl:AllDisjointClasses a rdfs:Class ;
+     rdfs:label "AllDisjointClasses" ;
+     rdfs:comment "The class of collections of pairwise disjoint classes." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Resource . 
+
+owl:AllDisjointProperties a rdfs:Class ;
+     rdfs:label "AllDisjointProperties" ;
+     rdfs:comment "The class of collections of pairwise disjoint properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Resource . 
+
+owl:Annotation a rdfs:Class ;
+     rdfs:label "Annotation" ;
+     rdfs:comment "The class of annotated annotations for which the RDF serialization consists of an annotated subject, predicate and object." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Resource . 
+
+owl:AnnotationProperty a rdfs:Class ;
+     rdfs:label "AnnotationProperty" ;
+     rdfs:comment "The class of annotation properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdf:Property . 
+
+owl:AsymmetricProperty a rdfs:Class ;
+     rdfs:label "AsymmetricProperty" ;
+     rdfs:comment "The class of asymmetric properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:ObjectProperty . 
+
+owl:Axiom a rdfs:Class ;
+     rdfs:label "Axiom" ;
+     rdfs:comment "The class of annotated axioms for which the RDF serialization consists of an annotated subject, predicate and object." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Resource . 
+
+owl:Class a rdfs:Class ;
+     rdfs:label "Class" ;
+     rdfs:comment "The class of OWL classes." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Class . 
+
+owl:DataRange a rdfs:Class ;
+     rdfs:label "DataRange" ;
+     rdfs:comment "The class of OWL data ranges, which are special kinds of datatypes. Note: The use of the IRI owl:DataRange has been deprecated as of OWL 2. The IRI rdfs:Datatype SHOULD be used instead." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Datatype . 
+
+owl:DatatypeProperty a rdfs:Class ;
+     rdfs:label "DatatypeProperty" ;
+     rdfs:comment "The class of data properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdf:Property . 
+
+owl:DeprecatedClass a rdfs:Class ;
+     rdfs:label "DeprecatedClass" ;
+     rdfs:comment "The class of deprecated classes." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Class . 
+
+owl:DeprecatedProperty a rdfs:Class ;
+     rdfs:label "DeprecatedProperty" ;
+     rdfs:comment "The class of deprecated properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdf:Property . 
+
+owl:FunctionalProperty a rdfs:Class ;
+     rdfs:label "FunctionalProperty" ;
+     rdfs:comment "The class of functional properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdf:Property . 
+
+owl:InverseFunctionalProperty a rdfs:Class ;
+     rdfs:label "InverseFunctionalProperty" ;
+     rdfs:comment "The class of inverse-functional properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:ObjectProperty . 
+
+owl:IrreflexiveProperty a rdfs:Class ;
+     rdfs:label "IrreflexiveProperty" ;
+     rdfs:comment "The class of irreflexive properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:ObjectProperty . 
+
+owl:NamedIndividual a rdfs:Class ;
+     rdfs:label "NamedIndividual" ;
+     rdfs:comment "The class of named individuals." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:Thing . 
+
+owl:NegativePropertyAssertion a rdfs:Class ;
+     rdfs:label "NegativePropertyAssertion" ;
+     rdfs:comment "The class of negative property assertions." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Resource . 
+
+owl:Nothing a owl:Class ;
+     rdfs:label "Nothing" ;
+     rdfs:comment "This is the empty class." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:Thing . 
+
+owl:ObjectProperty a rdfs:Class ;
+     rdfs:label "ObjectProperty" ;
+     rdfs:comment "The class of object properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdf:Property . 
+
+owl:Ontology a rdfs:Class ;
+     rdfs:label "Ontology" ;
+     rdfs:comment "The class of ontologies." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdfs:Resource . 
+
+owl:OntologyProperty a rdfs:Class ;
+     rdfs:label "OntologyProperty" ;
+     rdfs:comment "The class of ontology properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf rdf:Property . 
+
+owl:ReflexiveProperty a rdfs:Class ;
+     rdfs:label "ReflexiveProperty" ;
+     rdfs:comment "The class of reflexive properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:ObjectProperty . 
+
+owl:Restriction a rdfs:Class ;
+     rdfs:label "Restriction" ;
+     rdfs:comment "The class of property restrictions." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:Class . 
+
+owl:SymmetricProperty a rdfs:Class ;
+     rdfs:label "SymmetricProperty" ;
+     rdfs:comment "The class of symmetric properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:ObjectProperty . 
+
+owl:TransitiveProperty a rdfs:Class ;
+     rdfs:label "TransitiveProperty" ;
+     rdfs:comment "The class of transitive properties." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:subClassOf owl:ObjectProperty . 
+
+owl:Thing a owl:Class ;
+     rdfs:label "Thing" ;
+     rdfs:comment "The class of OWL individuals." ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> .
+     
+owl:allValuesFrom a rdf:Property ;
+     rdfs:label "allValuesFrom" ;
+     rdfs:comment "The property that determines the class that a universal property restriction refers to." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Class . 
+
+owl:annotatedProperty a rdf:Property ;
+     rdfs:label "annotatedProperty" ;
+     rdfs:comment "The property that determines the predicate of an annotated axiom or annotated annotation." ;
+     rdfs:domain rdfs:Resource ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Resource . 
+
+owl:annotatedSource a rdf:Property ;
+     rdfs:label "annotatedSource" ;
+     rdfs:comment "The property that determines the subject of an annotated axiom or annotated annotation." ;
+     rdfs:domain rdfs:Resource ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Resource . 
+
+owl:annotatedTarget a rdf:Property ;
+     rdfs:label "annotatedTarget" ;
+     rdfs:comment "The property that determines the object of an annotated axiom or annotated annotation." ;
+     rdfs:domain rdfs:Resource ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Resource . 
+
+owl:assertionProperty a rdf:Property ;
+     rdfs:label "assertionProperty" ;
+     rdfs:comment "The property that determines the predicate of a negative property assertion." ;
+     rdfs:domain owl:NegativePropertyAssertion ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:Property . 
+
+owl:backwardCompatibleWith a owl:AnnotationProperty, owl:OntologyProperty ;
+     rdfs:label "backwardCompatibleWith" ;
+     rdfs:comment "The annotation property that indicates that a given ontology is backward compatible with another ontology." ;
+     rdfs:domain owl:Ontology ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Ontology . 
+
+owl:bottomDataProperty a owl:DatatypeProperty ;
+     rdfs:label "bottomDataProperty" ;
+     rdfs:comment "The data property that does not relate any individual to any data value." ;
+     rdfs:domain owl:Thing ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Literal . 
+
+owl:bottomObjectProperty a owl:ObjectProperty ;
+     rdfs:label "bottomObjectProperty" ;
+     rdfs:comment "The object property that does not relate any two individuals." ;
+     rdfs:domain owl:Thing ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Thing . 
+
+owl:cardinality a rdf:Property ;
+     rdfs:label "cardinality" ;
+     rdfs:comment "The property that determines the cardinality of an exact cardinality restriction." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range xsd:nonNegativeInteger . 
+
+owl:complementOf a rdf:Property ;
+     rdfs:label "complementOf" ;
+     rdfs:comment "The property that determines that a given class is the complement of another class." ;
+     rdfs:domain owl:Class ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Class . 
+
+owl:datatypeComplementOf a rdf:Property ;
+     rdfs:label "datatypeComplementOf" ;
+     rdfs:comment "The property that determines that a given data range is the complement of another data range with respect to the data domain." ;
+     rdfs:domain rdfs:Datatype ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Datatype . 
+
+owl:deprecated a owl:AnnotationProperty ;
+     rdfs:label "deprecated" ;
+     rdfs:comment "The annotation property that indicates that a given entity has been deprecated." ;
+     rdfs:domain rdfs:Resource ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Resource . 
+
+owl:differentFrom a rdf:Property ;
+     rdfs:label "differentFrom" ;
+     rdfs:comment "The property that determines that two given individuals are different." ;
+     rdfs:domain owl:Thing ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Thing . 
+
+owl:disjointUnionOf a rdf:Property ;
+     rdfs:label "disjointUnionOf" ;
+     rdfs:comment "The property that determines that a given class is equivalent to the disjoint union of a collection of other classes." ;
+     rdfs:domain owl:Class ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List . 
+
+owl:disjointWith a rdf:Property ;
+     rdfs:label "disjointWith" ;
+     rdfs:comment "The property that determines that two given classes are disjoint." ;
+     rdfs:domain owl:Class ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Class . 
+
+owl:distinctMembers a rdf:Property ;
+     rdfs:label "distinctMembers" ;
+     rdfs:comment "The property that determines the collection of pairwise different individuals in a owl:AllDifferent axiom." ;
+     rdfs:domain owl:AllDifferent ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List . 
+
+owl:equivalentClass a rdf:Property ;
+     rdfs:label "equivalentClass" ;
+     rdfs:comment "The property that determines that two given classes are equivalent, and that is used to specify datatype definitions." ;
+     rdfs:domain rdfs:Class ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Class . 
+
+owl:equivalentProperty a rdf:Property ;
+     rdfs:label "equivalentProperty" ;
+     rdfs:comment "The property that determines that two given properties are equivalent." ;
+     rdfs:domain rdf:Property ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:Property . 
+
+owl:hasKey a rdf:Property ;
+     rdfs:label "hasKey" ;
+     rdfs:comment "The property that determines the collection of properties that jointly build a key." ;
+     rdfs:domain owl:Class ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List . 
+
+owl:hasSelf a rdf:Property ;
+     rdfs:label "hasSelf" ;
+     rdfs:comment "The property that determines the property that a self restriction refers to." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Resource . 
+
+owl:hasValue a rdf:Property ;
+     rdfs:label "hasValue" ;
+     rdfs:comment "The property that determines the individual that a has-value restriction refers to." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Resource . 
+
+owl:imports a owl:OntologyProperty ;
+     rdfs:label "imports" ;
+     rdfs:comment "The property that is used for importing other ontologies into a given ontology." ;
+     rdfs:domain owl:Ontology ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Ontology . 
+
+owl:incompatibleWith a owl:AnnotationProperty, owl:OntologyProperty ;
+     rdfs:label "incompatibleWith" ;
+     rdfs:comment "The annotation property that indicates that a given ontology is incompatible with another ontology." ;
+     rdfs:domain owl:Ontology ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Ontology . 
+
+owl:intersectionOf a rdf:Property ;
+     rdfs:label "intersectionOf" ;
+     rdfs:comment "The property that determines the collection of classes or data ranges that build an intersection." ;
+     rdfs:domain rdfs:Class ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List . 
+
+owl:inverseOf a rdf:Property ;
+     rdfs:label "inverseOf" ;
+     rdfs:comment "The property that determines that two given properties are inverse." ;
+     rdfs:domain owl:ObjectProperty ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:ObjectProperty . 
+
+owl:maxCardinality a rdf:Property ;
+     rdfs:label "maxCardinality" ;
+     rdfs:comment "The property that determines the cardinality of a maximum cardinality restriction." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range xsd:nonNegativeInteger . 
+
+owl:maxQualifiedCardinality a rdf:Property ;
+     rdfs:label "maxQualifiedCardinality" ;
+     rdfs:comment "The property that determines the cardinality of a maximum qualified cardinality restriction." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range xsd:nonNegativeInteger . 
+
+owl:members a rdf:Property ;
+     rdfs:label "members" ;
+     rdfs:comment "The property that determines the collection of members in either a owl:AllDifferent, owl:AllDisjointClasses or owl:AllDisjointProperties axiom." ;
+     rdfs:domain rdfs:Resource ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List . 
+
+owl:minCardinality a rdf:Property ;
+     rdfs:label "minCardinality" ;
+     rdfs:comment "The property that determines the cardinality of a minimum cardinality restriction." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range xsd:nonNegativeInteger . 
+
+owl:minQualifiedCardinality a rdf:Property ;
+     rdfs:label "minQualifiedCardinality" ;
+     rdfs:comment "The property that determines the cardinality of a minimum qualified cardinality restriction." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range xsd:nonNegativeInteger . 
+
+owl:onClass a rdf:Property ;
+     rdfs:label "onClass" ;
+     rdfs:comment "The property that determines the class that a qualified object cardinality restriction refers to." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Class . 
+
+owl:onDataRange a rdf:Property ;
+     rdfs:label "onDataRange" ;
+     rdfs:comment "The property that determines the data range that a qualified data cardinality restriction refers to." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Datatype . 
+
+owl:onDatatype a rdf:Property ;
+     rdfs:label "onDatatype" ;
+     rdfs:comment "The property that determines the datatype that a datatype restriction refers to." ;
+     rdfs:domain rdfs:Datatype ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Datatype . 
+
+owl:oneOf a rdf:Property ;
+     rdfs:label "oneOf" ;
+     rdfs:comment "The property that determines the collection of individuals or data values that build an enumeration." ;
+     rdfs:domain rdfs:Class ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List . 
+
+owl:onProperties a rdf:Property ;
+     rdfs:label "onProperties" ;
+     rdfs:comment "The property that determines the n-tuple of properties that a property restriction on an n-ary data range refers to." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List .
+
+owl:onProperty a rdf:Property ;
+     rdfs:label "onProperty" ;
+     rdfs:comment "The property that determines the property that a property restriction refers to." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:Property . 
+
+owl:priorVersion a owl:AnnotationProperty, owl:OntologyProperty ;
+     rdfs:label "priorVersion" ;
+     rdfs:comment "The annotation property that indicates the predecessor ontology of a given ontology." ;
+     rdfs:domain owl:Ontology ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Ontology . 
+
+owl:propertyChainAxiom a rdf:Property ;
+     rdfs:label "propertyChainAxiom" ;
+     rdfs:comment "The property that determines the n-tuple of properties that build a sub property chain of a given property." ;
+     rdfs:domain owl:ObjectProperty ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List . 
+
+owl:propertyDisjointWith a rdf:Property ;
+     rdfs:label "propertyDisjointWith" ;
+     rdfs:comment "The property that determines that two given properties are disjoint." ;
+     rdfs:domain rdf:Property ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:Property . 
+
+owl:qualifiedCardinality a rdf:Property ;
+     rdfs:label "qualifiedCardinality" ;
+     rdfs:comment "The property that determines the cardinality of an exact qualified cardinality restriction." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range xsd:nonNegativeInteger . 
+
+owl:sameAs a rdf:Property ;
+     rdfs:label "sameAs" ;
+     rdfs:comment "The property that determines that two given individuals are equal." ;
+     rdfs:domain owl:Thing ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Thing . 
+
+owl:someValuesFrom a rdf:Property ;
+     rdfs:label "someValuesFrom" ;
+     rdfs:comment "The property that determines the class that an existential property restriction refers to." ;
+     rdfs:domain owl:Restriction ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Class . 
+
+owl:sourceIndividual a rdf:Property ;
+     rdfs:label "sourceIndividual" ;
+     rdfs:comment "The property that determines the subject of a negative property assertion." ;
+     rdfs:domain owl:NegativePropertyAssertion ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Thing . 
+
+owl:targetIndividual a rdf:Property ;
+     rdfs:label "targetIndividual" ;
+     rdfs:comment "The property that determines the object of a negative object property assertion." ;
+     rdfs:domain owl:NegativePropertyAssertion ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Thing . 
+
+owl:targetValue a rdf:Property ;
+     rdfs:label "targetValue" ;
+     rdfs:comment "The property that determines the value of a negative data property assertion." ;
+     rdfs:domain owl:NegativePropertyAssertion ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Literal . 
+
+owl:topDataProperty a owl:DatatypeProperty ;
+     rdfs:label "topDataProperty" ;
+     rdfs:comment "The data property that relates every individual to every data value." ;
+     rdfs:domain owl:Thing ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Literal . 
+
+owl:topObjectProperty a owl:ObjectProperty ;
+     rdfs:label "topObjectProperty" ;
+     rdfs:comment "The object property that relates every two individuals." ;
+     rdfs:domain owl:Thing ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Thing . 
+
+owl:unionOf a rdf:Property ;
+     rdfs:label "unionOf" ;
+     rdfs:comment "The property that determines the collection of classes or data ranges that build a union." ;
+     rdfs:domain rdfs:Class ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List . 
+
+owl:versionInfo a owl:AnnotationProperty ;
+     rdfs:label "versionInfo" ;
+     rdfs:comment "The annotation property that provides version information for an ontology or another OWL construct." ;
+     rdfs:domain rdfs:Resource ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdfs:Resource .
+     
+owl:versionIRI a owl:OntologyProperty ;
+     rdfs:label "versionIRI" ;
+     rdfs:comment "The property that identifies the version IRI of an ontology." ;
+     rdfs:domain owl:Ontology ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range owl:Ontology . 
+
+owl:withRestrictions a rdf:Property ;
+     rdfs:label "withRestrictions" ;
+     rdfs:comment "The property that determines the collection of facet-value pairs that define a datatype restriction." ;
+     rdfs:domain rdfs:Datatype ;
+     rdfs:isDefinedBy <http://www.w3.org/2002/07/owl#> ;
+     rdfs:range rdf:List .
+     

--- a/data/vocabularies/rdf-schema.ttl
+++ b/data/vocabularies/rdf-schema.ttl
@@ -1,0 +1,109 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+<http://www.w3.org/2000/01/rdf-schema#> a owl:Ontology ;
+	dc:title "The RDF Schema vocabulary (RDFS)" .
+
+rdfs:Resource a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Resource" ;
+	rdfs:comment "The class resource, everything." .
+
+rdfs:Class a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Class" ;
+	rdfs:comment "The class of classes." ;
+	rdfs:subClassOf rdfs:Resource .
+
+rdfs:subClassOf a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "subClassOf" ;
+	rdfs:comment "The subject is a subclass of a class." ;
+	rdfs:range rdfs:Class ;
+	rdfs:domain rdfs:Class .
+
+rdfs:subPropertyOf a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "subPropertyOf" ;
+	rdfs:comment "The subject is a subproperty of a property." ;
+	rdfs:range rdf:Property ;
+	rdfs:domain rdf:Property .
+
+rdfs:comment a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "comment" ;
+	rdfs:comment "A description of the subject resource." ;
+	rdfs:domain rdfs:Resource ;
+	rdfs:range rdfs:Literal .
+
+rdfs:label a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "label" ;
+	rdfs:comment "A human-readable name for the subject." ;
+	rdfs:domain rdfs:Resource ;
+	rdfs:range rdfs:Literal .
+
+rdfs:domain a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "domain" ;
+	rdfs:comment "A domain of the subject property." ;
+	rdfs:range rdfs:Class ;
+	rdfs:domain rdf:Property .
+
+rdfs:range a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "range" ;
+	rdfs:comment "A range of the subject property." ;
+	rdfs:range rdfs:Class ;
+	rdfs:domain rdf:Property .
+
+rdfs:seeAlso a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "seeAlso" ;
+	rdfs:comment "Further information about the subject resource." ;
+	rdfs:range rdfs:Resource ;
+	rdfs:domain rdfs:Resource .
+
+rdfs:isDefinedBy a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:subPropertyOf rdfs:seeAlso ;
+	rdfs:label "isDefinedBy" ;
+	rdfs:comment "The defininition of the subject resource." ;
+	rdfs:range rdfs:Resource ;
+	rdfs:domain rdfs:Resource .
+
+rdfs:Literal a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Literal" ;
+	rdfs:comment "The class of literal values, eg. textual strings and integers." ;
+	rdfs:subClassOf rdfs:Resource .
+
+rdfs:Container a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Container" ;
+	rdfs:subClassOf rdfs:Resource ;
+	rdfs:comment "The class of RDF containers." .
+
+rdfs:ContainerMembershipProperty a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "ContainerMembershipProperty" ;
+	rdfs:comment """The class of container membership properties, rdf:_1, rdf:_2, ...,
+                    all of which are sub-properties of 'member'.""" ;
+	rdfs:subClassOf rdf:Property .
+
+rdfs:member a rdf:Property ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "member" ;
+	rdfs:comment "A member of the subject resource." ;
+	rdfs:domain rdfs:Resource ;
+	rdfs:range rdfs:Resource .
+
+rdfs:Datatype a rdfs:Class ;
+	rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+	rdfs:label "Datatype" ;
+	rdfs:comment "The class of RDF datatypes." ;
+	rdfs:subClassOf rdfs:Class .
+
+<http://www.w3.org/2000/01/rdf-schema#> rdfs:seeAlso <http://www.w3.org/2000/01/rdf-schema-more> .

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	},
 	"scripts": {
 		"annotate": "cross-env NODE_ENV=production NODE_NO_WARNINGS=1 node src/bin/es/annotate.mjs --field textBody_abstract_article --name dbpedia_entities --index arxiv_v6 --spotlight http://localhost:2222/rest/annotate --page-size 100 --include-metadata",
+		"getDBpediaOntology": "node src/bin/dbpedia/getOntology.mjs",
 		"lint": "eslint 'src/**/*.mjs' 'data/**/*.mjs'",
 		"rebuild": "npm run rebuildTestIndex && npm run rebuildEdgeCasesIndex",
 		"rebuildEdgeCasesIndex": "node src/bin/es/index.mjs delete edge-cases && sleep 1 && node src/bin/es/index.mjs create edge-cases && sleep 1 && node src/bin/es/document.mjs create edge-cases ./src/test/data/elastic_search_results/test_documents.json",

--- a/src/bin/dbpedia/README.md
+++ b/src/bin/dbpedia/README.md
@@ -1,0 +1,26 @@
+## getOntology.mjs
+
+Script to parse the DBpedia ontology. 
+
+Fetches DBpedia classes and associated parent classes using a SPARQL query
+to the DBPedia endpoint. We assure classes are from the DBpedia ontology using
+the following predicate object combination: 
+`rdfs:isDefinedBy <http://dbpedia.org/ontology/> .`,
+The full SPARQL query can be found [here](getOntology.sparql).
+
+Once the pairs of Class/Parent are fetched, the script then runs logic to
+produce a flat, Object based representation of the hierarchy, where keys
+are the class URIs, and the values take the form
+```js
+{
+   parentClass: "parentURI",
+   children: [
+        "childURI",
+        "childURI",
+        ...
+   ],
+   URI: "URI of this class"
+   depth: "Depth at which this class is found in the hierarcy"
+}
+```
+The parsed ontology can be found [here](../../../data/dbpedia/ontology.json)

--- a/src/bin/dbpedia/getOntology.mjs
+++ b/src/bin/dbpedia/getOntology.mjs
@@ -1,0 +1,67 @@
+import { promises as fs } from 'fs';
+
+import { saveObj } from '@svizzle/file';
+import * as _ from 'lamb';
+
+import { query } from 'sparql/query.mjs';
+import { hasNonAsciiCharacters } from 'util/string.mjs';
+
+
+const ONTOLOGY_SPARQL_QUERY = 'src/bin/dbpedia/getDBpediaOntology.sparql';
+const FILE_ONTOLOGY_JSON = 'data/dbpedia/ontology.json';
+
+const parse = classes => {
+	const classesWithRoot = [
+		..._.map(classes, class_ => ({...class_, children: []})),
+		{
+			class_: 'http://www.w3.org/2002/07/owl#Thing',
+			parentClass: null,
+			children: []
+		}
+	];
+	const tree = _.make(_.map(classesWithRoot, _.getKey('class_')), classesWithRoot);
+	_.map(classesWithRoot, node => {
+		if (node.parentClass && node.parentClass in tree) {
+			tree[node.parentClass].children.push(node.class_);
+		}
+	});
+
+	// tag depths
+	const root = 'http://www.w3.org/2002/07/owl#Thing';
+	let curr;
+	let stack = [{ node: root, depth: 0}];
+	while (stack.length) {
+		[curr, ...stack] = stack;
+		tree[curr.node].depth = curr.depth;
+		const { children } = tree[curr.node];
+		stack = [
+			...stack,
+			// eslint-disable-next-line no-loop-func
+			..._.map(children, child => ({ node: child, depth: curr.depth + 1}))
+		];
+	}
+
+	return tree;
+};
+
+
+const main = async () => {
+
+	const getOntologyQuery = await fs.readFile(ONTOLOGY_SPARQL_QUERY);
+	const result = await query(getOntologyQuery);
+	const parsedResult = _.map(
+		result.results.bindings,
+		binding => ({
+			..._.mapValues(binding, _.getKey('value')),
+		})
+	);
+	const englishClasses = _.filter(
+		parsedResult,
+		({ class_ }) => hasNonAsciiCharacters(class_)
+	);
+	const tree = parse(englishClasses);
+
+	saveObj(FILE_ONTOLOGY_JSON, 4)(tree);
+};
+
+main();

--- a/src/bin/dbpedia/getOntology.sparql
+++ b/src/bin/dbpedia/getOntology.sparql
@@ -1,0 +1,17 @@
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+SELECT DISTINCT * WHERE {
+  ?class_ a owl:Class .
+  ?class_ rdfs:isDefinedBy <http://dbpedia.org/ontology/> .
+  ?class_ rdfs:subClassOf ?parentClass .
+  {
+    ?parentClass rdfs:isDefinedBy <http://dbpedia.org/ontology/>
+  }
+  UNION
+  {
+    ?parentClass a owl:Class .
+    ?parentClass rdfs:label "Thing" .
+  }
+}

--- a/src/node_modules/dbpedia/requests.mjs
+++ b/src/node_modules/dbpedia/requests.mjs
@@ -1,6 +1,34 @@
 import * as _ from 'lamb';
 
+import { dbr, prefixes } from 'dbpedia/util.mjs';
 import { query } from 'sparql/query.mjs';
+import { getValue, stringify } from '@svizzle/utils';
+
+const sanitizeInput = input => {
+	const URIs = typeof input === 'string' ? [input] : input;
+	const sanitizedURIs = _.map(URIs, URI =>
+		URI.charAt(0) !== '<'
+			? URI.startsWith(dbr) ? `<${URI}>` : `<${dbr}${URI}>`
+			: URI
+	);
+	return sanitizedURIs;
+};
+
+const buildQuery = queries => {
+	const body = _.join(queries, '\nUNION\n');
+	const sparql = `
+	${prefixes}
+	SELECT * WHERE {
+		${body}
+	}`;
+	return sparql;
+};
+
+const makeRequest = async sparql => {
+	const { results } = await query(sparql);
+	const values = _.map(results.bindings, _.mapValuesWith(getValue));
+	return values;
+};
 
 /**
  * @function getEntityDetails
@@ -9,14 +37,8 @@ import { query } from 'sparql/query.mjs';
  * @returns a list of entities for the supplied DBPedia URIs.
  */
 export const getEntityDetails = async input => {
-	const dbr = 'http://dbpedia.org/resource';
-	const URIs = typeof input === 'string' ? [input] : input;
-	const sanitizedURIs = _.map(URIs, URI =>
-	    URI.charAt(0) !== '<'
-			? URI.startsWith(dbr) ? `<${URI}>` : `<${dbr}/${URI}>`
-			: URI
-	);
-	const individualQueries = _.map(sanitizedURIs, URI =>
+	const sanitizedURIs = sanitizeInput(input);
+	const queries = _.map(sanitizedURIs, URI =>
 		`{
 			BIND (${URI} as ?URI)
 			OPTIONAL { 
@@ -27,19 +49,8 @@ export const getEntityDetails = async input => {
 			OPTIONAL { ${URI} dbo:thumbnail ?imageURL . }
 		}`,
 	);
-	const body = _.join(individualQueries, '\nUNION\n');
-	const sparql = `
-    PREFIX dbo: <http://dbpedia.org/ontology/>
-    PREFIX dbr: <http://dbpedia.org/resource/>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
-    SELECT * WHERE {
-        ${body}
-    }`;
-
-	const { results } = await query(sparql);
-	const values = _.map(results.bindings, row =>
-    	_.mapValues(row, contents => contents.value)
-	);
+	const sparql = buildQuery(queries);
+	const values = await makeRequest(sparql);
 
 	// filter out bad encodings
 	const filteredValues = _.map(values, entity => {

--- a/src/node_modules/dbpedia/util.mjs
+++ b/src/node_modules/dbpedia/util.mjs
@@ -1,0 +1,10 @@
+export const prefixes =
+`
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX dbr: <http://dbpedia.org/resource/>
+PREFIX prov: <http://www.w3.org/ns/prov#>`;
+
+export const dbr = 'http://dbpedia.org/resource/';
+export const dbo = 'http://dbpedia.org/ontology/';
+

--- a/src/node_modules/util/array.mjs
+++ b/src/node_modules/util/array.mjs
@@ -11,4 +11,11 @@ const _batch = (arr, batchSize) => {
 };
 
 export const batch = _.pipe([_batch, _.filterWith(isNotNil)]);
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+export const range = n => Array.from(Array(n).keys());
 
+>>>>>>> 71c302d (Get ontological classes from Sparql Endpoint!)
+=======
+>>>>>>> d7385f9 (Implement requested changes)

--- a/src/node_modules/util/string.mjs
+++ b/src/node_modules/util/string.mjs
@@ -11,3 +11,6 @@ export const dedent = _.pipe([
 	_.joinWith('\n'),
 	trim
 ]);
+
+export const hasOnlyLatinCharacters = str => (/^[a-zA-Z:]+$/u).test(str);
+export const hasNonAsciiCharacters = str => (/^[\u0000-\u007f]*$/u).test(str);

--- a/src/test/ai_map.spec.mjs
+++ b/src/test/ai_map.spec.mjs
@@ -144,5 +144,3 @@ describe('aiMapDBpediaEntities', () => {
 		});
 	});
 });
-
-


### PR DESCRIPTION
This PR introduces code which automatically scrapes the current dbpedia
ontology and saves it to a json format.

closes https://github.com/nestauk/dap_dv_backends/issues/108