### PR TITLE
Spotlight Evaluation Backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,14 @@
 				"bcrypt": "^5.0.1",
 				"cli-progress": "^3.10.0",
 				"commander": "^9.0.0",
+				"cors": "^2.8.5",
 				"cross-env": "^7.0.3",
 				"express": "^4.18.1",
 				"fastify": "^4.2.1",
 				"lamb": "^0.60.0",
 				"redis": "^4.2.0",
 				"undici": "^4.13.0",
+				"uuid": "^8.3.2",
 				"winston": "^3.5.1"
 			},
 			"devDependencies": {
@@ -2395,6 +2397,50 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
 		},
+		"node_modules/content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"dependencies": {
+				"safe-buffer": "5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+		},
+		"node_modules/cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/cross-env": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -3628,6 +3674,57 @@
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+		},
+		"node_modules/methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/media-typer": {
@@ -6895,6 +6992,38 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
 		},
+		"content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"requires": {
+				"safe-buffer": "5.2.1"
+			}
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
+		"cookie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+		},
+		"cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"requires": {
+				"object-assign": "^4",
+				"vary": "^1"
+			}
+		},
 		"cross-env": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -8184,6 +8313,14 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
 			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+		},
+		"qs": {
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+			"integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+			"requires": {
+				"side-channel": "^1.0.4"
+			}
 		},
 		"randombytes": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
 		"bcrypt": "^5.0.1",
 		"cli-progress": "^3.10.0",
 		"commander": "^9.0.0",
+		"cors": "^2.8.5",
 		"cross-env": "^7.0.3",
-		"fastify": "^4.2.1",
 		"express": "^4.18.1",
 		"lamb": "^0.60.0",
 		"redis": "^4.2.0",
 		"undici": "^4.13.0",
+		"uuid": "^8.3.2",
 		"winston": "^3.5.1"
 	},
 	"description": "",
@@ -40,6 +41,7 @@
 	},
 	"scripts": {
 		"annotate": "cross-env NODE_ENV=production NODE_NO_WARNINGS=1 node src/bin/es/annotate.mjs --field textBody_abstract_article --name dbpedia_entities --index arxiv_v6 --spotlight http://localhost:2222/rest/annotate --page-size 100 --include-metadata",
+		"evaluationServer": "node src/servers/evaluator/app.mjs",
 		"getDBpediaOntology": "node src/bin/dbpedia/getOntology.mjs",
 		"lint": "eslint 'src/**/*.mjs' 'data/**/*.mjs'",
 		"rebuild": "npm run rebuildTestIndex && npm run rebuildEdgeCasesIndex",
@@ -51,6 +53,7 @@
 		"testAnnotationLocally": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --name dbpedia_entities --index test --page-size 10 --include-metadata",
 		"testAnnotationRemotely": "npm run rebuildTestIndex && sleep 5 && node src/bin/es/annotate.mjs --field textBody_abstract_article --index test --spotlight http://localhost:2222/rest/annotate --page-size 10",
 		"testEdgeCasesLocally": "npm run rebuildEdgeCasesIndex && sleep 1 && mocha --recursive -g 'edgeCases' src/test",
+		"testEvaluationServer": "mocha src/servers/evaluator/test",
 		"testPerformance": "bash src/test/perf/time.sh",
 		"testSpotlightLocally": "sh src/test/dbpedia/localCurlRequest.sh"
 	},

--- a/src/node_modules/conf/config.mjs
+++ b/src/node_modules/conf/config.mjs
@@ -5,6 +5,9 @@ export const spotlightEndpoint = `${ec2}:2222/rest/annotate`;
 export const confidenceValues = [
 	0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1,
 ];
+export const confidenceScores = [
+	0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
+];
 
 export const settings = {
 	snapshotSettings: {

--- a/src/node_modules/es/bulk.mjs
+++ b/src/node_modules/es/bulk.mjs
@@ -1,12 +1,15 @@
+import { stringify } from '@svizzle/utils';
 import * as _ from 'lamb';
 
 import { buildRequest, makeRequest } from 'es/requests.mjs';
-import { stringify } from '@svizzle/utils';
 
 const generateBulkPayload = (method, index) => _.pipe([
 	_.flatMapWith(doc =>
 		[
-			{ [method]: { "_id": doc.id, "_index": index } },
+			{ [method]: {
+				...doc._id && { "_id": doc._id },
+				"_index": index
+			} },
 			method === 'update' ? { doc: doc.data } : doc.data
 		]
 	),
@@ -20,7 +23,7 @@ const generateBulkPayload = (method, index) => _.pipe([
  * @param {string} domain - domain on which to update.
  * @param {string} index - index     on which to update.
  * @param {Object[]} documents - list of documents, where each object has an id
- * key and a data key. The data key is the document inteded to be created.
+ * key and a data key. The data key is the document intended to be created.
  * @param {string} method - the method to use (create, update, delete, etc.)
  * @returns {HttpResponse} response of the update reqeuest.
  */
@@ -31,13 +34,14 @@ export const bulkRequest = async (domain, index, documents, method) => {
 
 	// if payload is empty, no docs were supplied to the function
 	if (!payload.trim()) {
+		console.log("Payload empty");
 		return;
 	}
 	const request = buildRequest(domain, path, 'POST', { payload, contentType: 'application/x-ndjson' });
 	const { body: response, code } = await makeRequest(request);
-	if (code !== 200) {
+	if (response.errors) {
 		throw new Error(`Bulk request failed with response\n${stringify(response)}`);
 	}
 	// eslint-disable-next-line consistent-return
-	return response;
+	return { response, code };
 };

--- a/src/node_modules/es/document.mjs
+++ b/src/node_modules/es/document.mjs
@@ -1,5 +1,6 @@
-import { buildRequest, makeRequest } from 'es/requests.mjs';
 import { stringify } from '@svizzle/utils';
+
+import { buildRequest, makeRequest } from 'es/requests.mjs';
 
 /**
  * @function create
@@ -11,11 +12,14 @@ import { stringify } from '@svizzle/utils';
  * @param {string} [options.id=''] - id of document (if empty, ElasticSearch creates one for you).
  * @returns {HttpResponse} response of the update reqeuest.
  */
-export const create = async (domain, index, doc, { id = '' } = {}) => {
+export const create = async (domain, index, doc, { id = '', checkStatus=true} = {}) => {
 	const path = `${index}/_doc/${encodeURIComponent(id)}`;
 	const payload = doc;
 	const request = buildRequest(domain, path, 'POST', { payload });
 	const { body: response, code } = await makeRequest(request);
+	if (!checkStatus) {
+		return { response, code };
+	}
 	if (parseInt(code / 200, 10) !== 1) {
 		console.log(response);
 		throw Error(

--- a/src/node_modules/es/dump.mjs
+++ b/src/node_modules/es/dump.mjs
@@ -1,10 +1,8 @@
-import * as _ from 'lamb';
-
 import { SingleBar, Presets } from 'cli-progress';
+import * as _ from 'lamb';
 
 import { count } from 'es/index.mjs';
 import { scroll, clearScroll } from 'es/search.mjs';
-
 
 /**
  * @param {string} domain - domain on from which to dump data
@@ -13,13 +11,12 @@ import { scroll, clearScroll } from 'es/search.mjs';
  * @returns {Object} list of all documents on that index.
  */
 export const dump = async(domain, index, size) => {
-
 	const bar = new SingleBar(
 		{ etaBuffer: size * 10 },
 		Presets.rect
 	);
-
 	const totalDocuments = await count(domain, index);
+
 	bar.start(totalDocuments, 0);
 
 	const scroller = scroll(domain, index, {
@@ -37,7 +34,10 @@ export const dump = async(domain, index, size) => {
 			})
 		);
 	}
+
 	bar.stop();
+
 	clearScroll(domain);
+
 	return documents;
 };

--- a/src/node_modules/es/index.mjs
+++ b/src/node_modules/es/index.mjs
@@ -1,6 +1,7 @@
+import { stringify } from '@svizzle/utils';
+
 import { arxliveCopy } from 'conf/config.mjs';
 import { buildRequest, makeRequest } from 'es/requests.mjs';
-import { stringify } from '@svizzle/utils';
 
 /**
  * @function count

--- a/src/node_modules/es/pipeline.mjs
+++ b/src/node_modules/es/pipeline.mjs
@@ -1,5 +1,5 @@
-import { buildRequest, makeRequest } from 'es/requests.mjs';
 import { arxliveCopy } from 'conf/config.mjs';
+import { buildRequest, makeRequest } from 'es/requests.mjs';
 
 /**
  *

--- a/src/node_modules/es/query.mjs
+++ b/src/node_modules/es/query.mjs
@@ -1,0 +1,22 @@
+import { stringify } from '@svizzle/utils';
+
+import { arxliveCopy } from 'conf/config.mjs';
+import { buildRequest, makeRequest } from 'es/requests.mjs';
+
+export const query = async (query_, index, domain=arxliveCopy) => {
+	const path = `${index}/_search`;
+	const payload = query_;
+	const request = buildRequest(
+		domain,
+		path,
+		'POST',
+		payload
+	);
+	const { body: response, code } = await makeRequest(request, { verbose: true });
+
+	if (code !== 200) {
+		throw new Error(`Query failed with response ${stringify(response)}`);
+	}
+
+	return response;
+};

--- a/src/node_modules/es/requests.mjs
+++ b/src/node_modules/es/requests.mjs
@@ -1,8 +1,9 @@
-import { defaultProvider } from '@aws-sdk/credential-provider-node';
-import { SignatureV4 } from '@aws-sdk/signature-v4';
-import { NodeHttpHandler } from '@aws-sdk/node-http-handler';
 import sha256 from '@aws-crypto/sha256-browser';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import { NodeHttpHandler } from '@aws-sdk/node-http-handler';
 import { HttpRequest } from '@aws-sdk/protocol-http';
+import { SignatureV4 } from '@aws-sdk/signature-v4';
+
 const { Sha256 } = sha256;
 
 const signer = new SignatureV4({
@@ -87,4 +88,3 @@ export const makeRequest = async (request, { verbose = false } = {}) => {
 		body: responseBody,
 	};
 };
-

--- a/src/node_modules/es/snapshot.mjs
+++ b/src/node_modules/es/snapshot.mjs
@@ -1,5 +1,5 @@
-import { buildRequest, makeRequest } from 'es/requests.mjs';
 import { settings as globalSettings } from 'conf/config.mjs';
+import { buildRequest, makeRequest } from 'es/requests.mjs';
 
 const settings = globalSettings.snapshotSettings;
 

--- a/src/node_modules/es/update.mjs
+++ b/src/node_modules/es/update.mjs
@@ -1,5 +1,6 @@
-import * as _ from 'lamb';
 import { stringify } from '@svizzle/utils';
+import * as _ from 'lamb';
+
 import { buildRequest, makeRequest } from 'es/requests.mjs';
 
 /**
@@ -11,16 +12,30 @@ import { buildRequest, makeRequest } from 'es/requests.mjs';
  * @param {Object} doc - an object containing the new fields and properties that constitute the update.
  * @returns {HttpResponse} response of the update reqeuest.
  */
-export const update = async (domain, index, id, doc, options = {}) => {
+export const update = async (
+	domain,
+	index,
+	id,
+	doc,
+	payloadOptions={},
+	query={},
+	{ checkStatus=true } = {}
+) => {
 	const path = `${index}/_update/${encodeURIComponent(id)}`;
-	const payload = { doc };
-	const request = buildRequest(domain, path, 'POST', { payload });
-	const { body: response, code } = await makeRequest(request, options);
+	const payload = { ...payloadOptions, doc };
+	const request = buildRequest(domain, path, 'POST', { payload, query });
+	const { body: response, code } = await makeRequest(request);
+
+	if (!checkStatus) {
+		return { response, code };
+	}
+
 	if (code !== 200) {
 		throw Error(
-			`Update failed at ${domain}/${index} for document with ID: ${id}. 
+			`Update failed at ${domain}/${index} for document with ID: ${id}.
 			Response:\n${stringify(response)}`
 		);
 	}
+
 	return response;
 };

--- a/src/node_modules/logging/logging.mjs
+++ b/src/node_modules/logging/logging.mjs
@@ -1,5 +1,5 @@
-import { createLogger, format, transports } from 'winston';
 import * as fs from 'fs/promises';
+import { createLogger, format, transports } from 'winston';
 
 await fs.mkdir('logs', { recursive: true });
 

--- a/src/servers/evaluator/README.md
+++ b/src/servers/evaluator/README.md
@@ -1,0 +1,39 @@
+# Setup
+
+To get this server to work locally, do the following:
+
+- Install Node.js and npm (tested with Node.js `v18.4.0` and npm `8.12.1`)
+- Install Redis and ensure the service is running and exposed on its default port `6379` (tested with Redis `7.0.2)
+- Set NODE_ENV to one of the following: `dev`, `staging`, `release`
+- Run the server using `npm run evaluationServer`
+
+If you want the app to run on a remote server and you wish to forward HTTP
+traffic, install nginx on the server and either copy the `nginx.conf` contents
+to /etc/nginx/nginx.conf or symlink the conf file to the one found in this repo:
+`sudo ln -sf /path/to/repo/src/servers/evaluator/nginx.conf /etc/nginx/nginx.conf`
+
+Then reload the server: `sudo nginx -s reload` 
+
+The current frontend is deployed using Netlify, in which case secure access is
+needed to the endpoints. In this case, we use `certbot` to aquire a free SSL
+cert authorised by `letsencrypt` - this will require a domain purchase and some
+modifications to the nginx.conf file to set up. More documentation can be found
+[here](https://certbot.eff.org/).
+
+You'll most likely have to change the ElasticSearch indices if you don't have
+access to the Nesta defaults.
+
+# Current Servers
+
+- `dev`: dev.ai-map.dv.dap-tools.uk
+- `staging`: staging.ai-map.dv.dap-tools.uk
+
+A release server will also be provisioned when we finish testing the service.
+# AWS 
+
+Use AMI `spotlight-evaluator-backend` (id: `ami-0f140f131ee80beff`) if you
+wish to quickly create new instances with the neccessary packages/software
+installed.
+
+Use Security Group `spotlight-evaluator` (id: `sg-012d3b94477f1b162`) as 
+security group.

--- a/src/servers/evaluator/app.mjs
+++ b/src/servers/evaluator/app.mjs
@@ -1,0 +1,59 @@
+import cors from 'cors';
+import express from 'express';
+
+import { serverPort } from './config.mjs';
+import { redisClient } from './db.mjs';
+import {
+	getNextOrgIdsForUser,
+	getOrgById,
+	getOrgWithValidEntities,
+	saveEvaluation,
+} from './logic.mjs';
+
+const app = express();
+
+/* middleware */
+
+app.use(cors());
+app.use(express.json()); // for parsing application/json
+
+/* endpoints */
+
+app.post('/next_ids', async (req, res) => {
+	const { userId, chunkSize } = req.body;
+	const documentsEvaluated = await redisClient.sMembers(userId);
+	const orgIds = getNextOrgIdsForUser(documentsEvaluated, chunkSize);
+
+	res.status(200).send({orgIds});
+});
+
+app.post('/next_org', async (req, res) => {
+	const { userId } = req.body;
+	const documentsEvaluated = await redisClient.sMembers(userId);
+	const [ orgId ] = getNextOrgIdsForUser(documentsEvaluated, 1);
+	const org = await getOrgById(orgId);
+	const filteredOrg = getOrgWithValidEntities(org);
+
+	res.status(200).send({org: filteredOrg});
+});
+
+app.post('/eval/:orgId', async (req, res) => {
+	const { userId, topics } = req.body;
+	const code = await saveEvaluation(userId, req.params.orgId, topics);
+
+	if (code === 200 || code === 201) {
+		await redisClient.sAdd(userId, req.params.orgId);
+	}
+
+	res.status(code).send({});
+});
+
+app.get('/orgs/:orgId', async(req, res) => {
+	const org = await getOrgById(req.params.orgId);
+
+	res.status(200).send({org});
+});
+
+app.listen(serverPort, () => {
+	console.log(`Listening on port ${serverPort}`);
+});

--- a/src/servers/evaluator/config.mjs
+++ b/src/servers/evaluator/config.mjs
@@ -1,0 +1,35 @@
+/* indices */
+
+export const mainIndex = 'ai_map';
+export const devIndex = 'ai_map_evaluations_dev';
+export const stagingIndex = 'ai_map_evaluations_staging';
+
+// not created yet
+export const productionIndex = 'ai_map_evaluations_production';
+
+export let evaluationIndex;
+
+
+// eslint-disable-next-line no-process-env
+switch (process.env.NODE_ENV) {
+	case 'dev':
+		evaluationIndex = devIndex;
+		break;
+	case 'staging':
+		evaluationIndex = stagingIndex;
+		break;
+	case 'release':
+		evaluationIndex = productionIndex;
+		break;
+	default:
+		evaluationIndex = devIndex;
+		break;
+}
+
+/* server */
+
+export const serverPort = 4000;
+
+/* filtering */
+
+export const confidenceThreshold = 60;

--- a/src/servers/evaluator/db.mjs
+++ b/src/servers/evaluator/db.mjs
@@ -1,0 +1,37 @@
+import * as _ from 'lamb';
+import { createClient } from 'redis';
+
+import { arxliveCopy } from 'conf/config.mjs';
+import { scroll, clearScroll } from 'es/search.mjs';
+
+import * as serverConfig from './config.mjs';
+
+export const redisClient = createClient();
+
+redisClient.on('error', err => console.log('Redis Client Error', err));
+
+await redisClient.connect();
+await redisClient.flushDb();
+
+const seed = async () => {
+	const scroller = scroll(
+		arxliveCopy,
+		serverConfig.evaluationIndex,
+		{ size: 1000 }
+	);
+
+	let page;
+	for await (page of scroller) {
+		const docs = page.hits.hits;
+		await Promise.all(_.map(docs, ({_source}) =>
+			redisClient.sAdd(_source.userId, _source.orgEsId)
+		));
+	}
+
+	// empty index means no page is returned
+	if (page) {
+		clearScroll(arxliveCopy, page._scroll_id);
+	}
+};
+
+await seed();

--- a/src/servers/evaluator/logic.mjs
+++ b/src/servers/evaluator/logic.mjs
@@ -1,0 +1,115 @@
+import { isIterableNotEmpty } from '@svizzle/utils';
+import * as _ from 'lamb';
+
+import { arxliveCopy, confidenceScores } from 'conf/config.mjs';
+import { get } from 'es/document.mjs';
+import { scroll, clearScroll } from 'es/search.mjs';
+import { bulkRequest } from 'es/bulk.mjs';
+
+import * as serverConfig from './config.mjs';
+
+/* utils */
+const getEntities = _.getPath('_source.dbpedia_entities');
+
+const getValidEntities = entities => {
+
+	const lowConfidenceScores = _.filter(
+		confidenceScores,
+		c => c <= serverConfig.confidenceThreshold
+	);
+
+	const entitiesAtConfidence = _.map(
+		lowConfidenceScores,
+		confidence => _.filter(entities, e => e.confidence >= confidence)
+	);
+	const nonEmptyEntities = _.filter(entitiesAtConfidence, e => e.length);
+	const validEntities = nonEmptyEntities[nonEmptyEntities.length-1];
+	return validEntities;
+};
+
+export const getOrgWithValidEntities = _.updatePath(
+	'_source.dbpedia_entities',
+	getValidEntities
+);
+
+const getOrgMeanConfidence = _.pipe([
+	getEntities,
+	_.pluck('confidence'),
+	_.mean,
+]);
+
+const getOrgVarianceOf = mean =>
+	_.pipe([
+		getEntities,
+		_.reduceWith(
+			(v, entity) => v + Math.pow(entity.confidence - mean, 2),
+			0
+		),
+	]);
+
+const augmentOrg = org => {
+	const meanConfidence = getOrgMeanConfidence(org);
+	const variance = getOrgVarianceOf(meanConfidence)(org);
+	const std = Math.pow(variance, 0.5);
+
+	return { ...org, meanConfidence, variance, std };
+};
+
+const sortAugmentedOrgs = _.sortWith([
+	_.getKey('meanConfidence'),
+	_.sorterDesc(_.getKey('std')),
+]);
+
+const getSortedAugmentedOrgs = _.pipe([
+	_.mapWith(getOrgWithValidEntities),
+	_.filterWith(v => v._source.dbpedia_entities.length !== 0),
+	_.mapWith(augmentOrg),
+	sortAugmentedOrgs,
+]);
+
+/* setup */
+
+const getOrgs = async () => {
+	const scroller = scroll(arxliveCopy, 'ai_map', { size: 1000 });
+
+	let orgs = [];
+	let page;
+	for await (page of scroller) {
+		orgs.push(...page.hits.hits);
+	}
+
+	// empty index means no page is returned
+	if (page) {
+		clearScroll(arxliveCopy, page._scroll_id);
+	}
+	return orgs;
+};
+
+const orgs = await getOrgs();
+const nonEmptyOrgs = _.filter(orgs, _.pipe([getEntities, isIterableNotEmpty]));
+const sortedAugmentedOrgs = getSortedAugmentedOrgs(nonEmptyOrgs);
+export const sortedOrgIds = _.map(sortedAugmentedOrgs, _.getKey('_id'));
+
+export const getNextOrgIdsForUser = (documentsEvaluated, chunkSize = 100) => {
+	const nextOrgs = _.difference(sortedOrgIds, documentsEvaluated);
+	return nextOrgs.slice(0, chunkSize);
+};
+
+export const saveEvaluation = async (userId, orgEsId, topics) => {
+	const documents = _.values(
+		_.mapValues(topics, (data, URI) => ({
+			data: { orgEsId, userId, URI, ...data },
+		}))
+	);
+	const { code } = await bulkRequest(
+		arxliveCopy,
+		serverConfig.devIndex,
+		documents,
+		'index'
+	);
+
+	return code;
+};
+
+export const getOrgById = orgId =>
+	get(arxliveCopy, serverConfig.mainIndex, orgId);

--- a/src/servers/evaluator/nginx.conf
+++ b/src/servers/evaluator/nginx.conf
@@ -1,0 +1,8 @@
+events {}
+http {
+    server {
+        location / {
+            proxy_pass http://localhost:4000;
+        }
+    }
+}


### PR DESCRIPTION
PR for the Evaluation tool backend. The backend currently supports
two REST API endpoints, `/next_id`, which provides the next Organisation
ID to be evaluated for a given user, and `/eval/:orgId`, which accepts
a body with the users' evaluations and saves them to an ElasticSearch
index.

closes #124