### PR TITLE
Extract entities to index

### DIFF
--- a/src/bin/es/entities.mjs
+++ b/src/bin/es/entities.mjs
@@ -1,0 +1,38 @@
+import { Command } from 'commander';
+import * as _ from 'lamb';
+
+import { arxliveCopy } from 'conf/config.mjs';
+import { getEntityAbstract } from 'dbpedia/requests.mjs';
+import { bulkRequest } from 'es/bulk.mjs';
+import { getEntities } from 'es/entities.mjs';
+import { createIndex } from 'es/index.mjs';
+import { batchIterate, batchIterateFlatten } from 'util/array.mjs';
+
+const program = new Command();
+
+program
+.command('extract')
+.description('Creates an index where each document is an entity extracted from the set of all entities previously annotated in the input index')
+.argument('<Input index>', 'Input index name')
+.argument('<Output index>', 'Output index name (doesn\'t have to exist)')
+.argument('[domain]', 'domain on which to create index', arxliveCopy)
+.action(async (inputIndex, outputIndex, domain) => {
+	const entities = await getEntities(inputIndex, domain);
+	await createIndex(outputIndex, domain);
+	const abstracts = await batchIterateFlatten(
+		entities,
+		getEntityAbstract,
+		{ batchSize: 100 }
+	);
+	const payloads = _.map(
+		abstracts,
+		abstract => ({ "_id": abstract.URI, data: abstract })
+	);
+	await batchIterate(
+		payloads,
+		payload => bulkRequest(domain, outputIndex, payload, 'create'),
+		{ batchSize: 100 }
+	);
+});
+
+program.parse();

--- a/src/node_modules/dbpedia/requests.mjs
+++ b/src/node_modules/dbpedia/requests.mjs
@@ -14,6 +14,11 @@ const sanitizeInput = input => {
 	return sanitizedURIs;
 };
 
+const buildIndividualQueries = (inputs, template) => _.map(
+	inputs,
+	input => _.replace(/\$\$URI\$\$/gu, input)(template)
+);
+
 const buildQuery = queries => {
 	const body = _.join(queries, '\nUNION\n');
 	const sparql = `
@@ -30,6 +35,14 @@ const makeRequest = async sparql => {
 	return values;
 };
 
+const genericRequest = async (input, template) => {
+	const sanitizedInput = sanitizeInput(input);
+	const queries = buildIndividualQueries(sanitizedInput, template);
+	const sparql = buildQuery(queries);
+	const values = await makeRequest(sparql);
+	return values;
+};
+
 /**
  * @function getEntityDetails
  * @description provides details such as imageURL and abstract for supplied DBpedia URIs
@@ -37,20 +50,18 @@ const makeRequest = async sparql => {
  * @returns a list of entities for the supplied DBPedia URIs.
  */
 export const getEntityDetails = async input => {
-	const sanitizedURIs = sanitizeInput(input);
-	const queries = _.map(sanitizedURIs, URI =>
+	const template =
 		`{
-			BIND (${URI} as ?URI)
+			BIND ($$URI$$ as ?URI)
 			OPTIONAL { 
-				${URI} dbo:abstract ?abstract .
+				$$URI$$ dbo:abstract ?abstract .
 				FILTER (langMatches(lang(?abstract),"en"))
 			}
-			OPTIONAL { ${URI} prov:wasDerivedFrom ?derivedFrom . }
-			OPTIONAL { ${URI} dbo:thumbnail ?imageURL . }
-		}`,
-	);
-	const sparql = buildQuery(queries);
-	const values = await makeRequest(sparql);
+			OPTIONAL { $$URI$$ prov:wasDerivedFrom ?derivedFrom . }
+			OPTIONAL { $$URI$$ dbo:thumbnail ?imageURL . }
+		}`;
+
+	const values = await genericRequest(input, template);
 
 	// filter out bad encodings
 	const filteredValues = _.map(values, entity => {
@@ -64,6 +75,17 @@ export const getEntityDetails = async input => {
 	});
 
 	return filteredValues;
+};
+
+export const getEntityAbstract = input => {
+	const template = `{
+		BIND ($$URI$$ as ?URI)
+		OPTIONAL { 
+			$$URI$$ dbo:abstract ?abstract .
+			FILTER (langMatches(lang(?abstract),"en"))
+		}
+	}`;
+	return genericRequest(input, template);
 };
 
 export const isDisambiguation = async input => {

--- a/src/node_modules/es/entities.mjs
+++ b/src/node_modules/es/entities.mjs
@@ -17,7 +17,8 @@ export const getEntities = async(
 
 	const scroller = scroll(domain, index, { size: 10000, });
 	const uriCounts = {};
-	for await (let page of scroller) {
+	let page;
+	for await (page of scroller) {
 		_.forEach(page.hits.hits, doc => {
 			_.forEach(doc._source.dbpedia_entities, ({ URI }) => {
 				const key = asTitle
@@ -27,9 +28,9 @@ export const getEntities = async(
 			});
 		});
 	}
-
-	clearScroll(domain);
-
+	if (page) {
+		clearScroll(domain, page._scroll_id);
+	}
 	const entities = _.keys(uriCounts);
 	return entities;
 };

--- a/src/node_modules/util/array.mjs
+++ b/src/node_modules/util/array.mjs
@@ -1,4 +1,4 @@
-import { isNotNil } from '@svizzle/utils';
+import { isNotNil, mergeObjects } from '@svizzle/utils';
 import * as cliProgress from 'cli-progress';
 import * as _ from 'lamb';
 
@@ -13,18 +13,30 @@ const _batch = (arr, batchSize) => {
 
 export const batch = _.pipe([_batch, _.filterWith(isNotNil)]);
 
-export async function batchIterate(iterable, func, { concat=true }={}) {
+export const batchIterate = async(iterable, func, options={}) => {
+	const { batchSize=100 } = options;
+
 	const bar = new cliProgress.Bar(null, cliProgress.Presets.rect);
 	bar.start(iterable.length, 0);
-	const batches = batch(iterable, 100);
+	const batches = batch(iterable, batchSize);
 	let results = [];
 	for (const batch_ of batches) {
 		// eslint-disable-next-line no-await-in-loop
 		const result = await func(batch_);
-		results = concat ? [...results, ...result] : [...results, result];
+		results = [...results, result];
 		bar.increment(batch_.length);
 	}
 
 	bar.stop();
 	return results;
-}
+};
+
+export const batchIterateFlatten = async(iterable, func, options) => {
+	const results = await batchIterate(iterable, func, options);
+	return _.shallowFlatten(results);
+};
+
+export const batchIterateMerge = async(iterable, func, options) => {
+	const results = await batchIterate(iterable, func, options);
+	return mergeObjects(results);
+};


### PR DESCRIPTION
PR introduces script which takes a previously annotated index as input,
extracts all unique entities for that index, then creates a new index
with a document for each extracted entity. We also save that entity's
abstract to the index.

closes #128