### PR TITLE
Set up terraform state endpoint

### DIFF
--- a/src/node_modules/terraform/commands.mjs
+++ b/src/node_modules/terraform/commands.mjs
@@ -17,9 +17,11 @@ export const apply = dir => {
 };
 
 
-export const destroy = dir => {
+export const destroy = (dir, callback=displayCommandOutput) => {
 	const destroyCommand =
 		`terraform -chdir=${dir} destroy -auto-approve`;
 	console.log("[+] Terraform - Destroying...");
-	exec(destroyCommand, displayCommandOutput);
+
+
+	exec(destroyCommand, callback);
 };

--- a/src/node_modules/terraform/configuration.mjs
+++ b/src/node_modules/terraform/configuration.mjs
@@ -1,7 +1,9 @@
-import { saveObj } from '@svizzle/file';
+import * as fs from 'fs';
+
 import * as _ from 'lamb';
 
 import { ami, scaffold, spotlightInstanceType } from 'conf/infrastructure.mjs';
+import { stringify } from '@svizzle/utils';
 
 
 export const generateConfiguration = (workers, path=null) => {
@@ -41,7 +43,7 @@ export const generateConfiguration = (workers, path=null) => {
 	};
 
 	if (path) {
-		saveObj(path, 4)(configuration);
+		fs.writeFileSync(path, stringify(configuration));
 	}
 	return configuration;
 };

--- a/src/node_modules/util/shell.mjs
+++ b/src/node_modules/util/shell.mjs
@@ -1,11 +1,21 @@
-export const displayCommandOutput = (error, stdout, stderr) => {
+export const displayCommandOutput = (
+	error,
+	stdout,
+	stderr,
+	{ warnings=false } = {}
+) => {
 	if (error) {
 		console.log(`error: ${error.message}`);
 		return;
 	}
 	if (stderr) {
+		if (stderr.toLowerCase().startsWith('warning') && !warnings) {
+			return;
+		}
 		console.log(`stderr: ${stderr}`);
 		return;
 	}
-	console.log(`stdout: ${stdout}`);
+	if (stdout.length > 0) {
+		console.log(`stdout: ${stdout}`);
+	}
 };

--- a/src/servers/annotation/data/spotlightResponse.json
+++ b/src/servers/annotation/data/spotlightResponse.json
@@ -1,0 +1,64 @@
+{
+    "@text": "The Semantic Web, sometimes known as Web 3.0 \n(not to be confused with Web3), is an extension of the World Wide Web through \nstandards[1] set by the World Wide Web Consortium (W3C). The goal of the \nSemantic Web is to make Internet data machine-readable.",
+    "@confidence": 60,
+    "@support": 0,
+    "@types": "",
+    "@sparql": "",
+    "@policy": "whitelist",
+    "Resources": [
+      {
+        "@URI": "http://dbpedia.org/resource/Semantic_Web",
+        "@support": 964,
+        "@types": "",
+        "@surfaceForm": "Semantic Web",
+        "@offset": 4,
+        "@similarityScore": 1,
+        "@percentageOfSecondRank": 2.0735100448316815e-21
+      },
+      {
+        "@URI": "http://dbpedia.org/resource/Semantic_Web",
+        "@support": 964,
+        "@types": "",
+        "@surfaceForm": "Web 3.0",
+        "@offset": 37,
+        "@similarityScore": 1,
+        "@percentageOfSecondRank": 0
+      },
+      {
+        "@URI": "http://dbpedia.org/resource/World_Wide_Web",
+        "@support": 5716,
+        "@types": "",
+        "@surfaceForm": "World Wide Web",
+        "@offset": 101,
+        "@similarityScore": 0.9999999940348516,
+        "@percentageOfSecondRank": 5.964256967844491e-9
+      },
+      {
+        "@URI": "http://dbpedia.org/resource/World_Wide_Web_Consortium",
+        "@support": 2230,
+        "@types": "",
+        "@surfaceForm": "World Wide Web Consortium (W3C)",
+        "@offset": 149,
+        "@similarityScore": 1,
+        "@percentageOfSecondRank": 0
+      },
+      {
+        "@URI": "http://dbpedia.org/resource/Semantic_Web",
+        "@support": 964,
+        "@types": "",
+        "@surfaceForm": "Semantic Web",
+        "@offset": 199,
+        "@similarityScore": 1,
+        "@percentageOfSecondRank": 2.0735100448316815e-21
+      },
+      {
+        "@URI": "http://dbpedia.org/resource/World_Wide_Web",
+        "@support": 5716,
+        "@types": "",
+        "@surfaceForm": "Internet",
+        "@offset": 223,
+        "@similarityScore": 0.9918346778128737,
+        "@percentageOfSecondRank": 0.008232521544245103
+      }
+    ]
+  }

--- a/src/servers/annotation/src/app.mjs
+++ b/src/servers/annotation/src/app.mjs
@@ -1,0 +1,21 @@
+import Fastify from 'fastify';
+
+import { PORT } from './config.mjs';
+import { routes } from './routes.mjs';
+
+const fastify = Fastify({
+	logger: true
+});
+
+fastify.register(routes);
+
+const start = async () => {
+	try {
+		await fastify.listen({ port: PORT });
+		console.log(`Listening at http://localhost:${PORT}`);
+	} catch (err) {
+		fastify.log.error(err);
+		throw new Error(err);
+	}
+};
+start();

--- a/src/servers/annotation/src/config.mjs
+++ b/src/servers/annotation/src/config.mjs
@@ -1,0 +1,14 @@
+export const PORT = 4000;
+
+export const terraformServerAddress = "http://3.8.192.33";
+export const stateEndpoint = new URL('state', terraformServerAddress);
+export const annotationEndpoint = new URL('annotate', terraformServerAddress);
+export const statusEndpoint = new URL('status', terraformServerAddress);
+// eslint-disable-next-line no-process-env
+const nodeEnv = process.env.NODE_ENV || 'development';
+
+const BACKEND_BASES = {
+	development: `http://localhost:${PORT}`,
+};
+
+export const BACKEND_BASE = BACKEND_BASES[nodeEnv];

--- a/src/servers/annotation/src/routes.mjs
+++ b/src/servers/annotation/src/routes.mjs
@@ -1,0 +1,22 @@
+import { statusEndpoint, annotationEndpoint } from './config.mjs';
+import { testSpotlightEnpoint } from './util.mjs';
+
+export const routes = (fastify, options, done) => {
+
+	fastify.get('/status', async (_, reply) => {
+		const response = await fetch(statusEndpoint, {
+			method: 'GET'
+		});
+		const statusResponse = await response.json();
+		if (statusResponse.status === 'up') {
+			statusResponse.status = testSpotlightEnpoint(annotationEndpoint)
+				? 'ready'
+				: 'scheduling';
+		}
+		return reply.send(
+			statusResponse
+		);
+	});
+
+	done();
+};

--- a/src/servers/annotation/src/util.mjs
+++ b/src/servers/annotation/src/util.mjs
@@ -1,0 +1,25 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as _ from 'lamb';
+import { fileURLToPath } from 'url';
+
+import { isEqualTo } from '@svizzle/utils';
+
+import { annotate } from 'dbpedia/spotlight.mjs';
+import { annotationEndpoint } from './config.mjs';
+export const __filename = fileURLToPath(import.meta.url);
+export const __dirname = path.dirname(__filename);
+
+const spotlightResponse = JSON.parse(
+	await fs.readFile(path.join(__dirname, '../data', 'spotlightResponse.json'))
+);
+
+export const testSpotlightEnpoint = async endpoint => {
+
+	const text = spotlightResponse['@text'];
+	const confidence = parseInt(spotlightResponse['@confidence'], 10) / 100;
+	const result = await annotate(text, confidence, endpoint);
+	const compare = isEqualTo(spotlightResponse);
+
+	return compare(result);
+};

--- a/src/servers/spotlight/app.mjs
+++ b/src/servers/spotlight/app.mjs
@@ -2,7 +2,10 @@ import express from 'express';
 import * as path from 'path';
 
 import { setup } from './infrastructure.mjs';
+import { displayCommandOutput } from 'util/shell.mjs';
 import { destroy } from '../../node_modules/terraform/commands.mjs';
+import { state } from './state.mjs';
+import { getCurrentState } from '../../node_modules/terraform/state.mjs';
 
 const SERVER_DIRECTORY = 'src/servers/spotlight';
 const TERRAFORM_DIRECTORY = path.join(SERVER_DIRECTORY, 'terraform');
@@ -10,17 +13,33 @@ const TERRAFORM_DIRECTORY = path.join(SERVER_DIRECTORY, 'terraform');
 const app = express();
 const port = 3000;
 
+
 app.use(express.json()); // for parsing application/json
 
 app.post('/provision', (req, res) => {
 	const { workers=4 } = req.body;
+	state.status = { status: 'scheduling', workers };
 	setup(workers);
-	res.status(200).send();
+	res.send();
 });
 
 app.post('/teardown', (_, res) => {
-	destroy(TERRAFORM_DIRECTORY);
-	res.status(200).send();
+	state.status = { status: 'destroying' };
+	const callback = (err, stdout, stderr) => {
+		state.status = { status: 'down' };
+		return displayCommandOutput(err, stdout, stderr);
+	};
+	destroy(TERRAFORM_DIRECTORY, callback);
+	res.send();
+});
+
+app.get('/state', async (_, res) => {
+	const terraformState = await getCurrentState(TERRAFORM_DIRECTORY);
+	res.send(terraformState);
+});
+
+app.get('/status', (_, res) => {
+	res.send(state.status);
 });
 
 app.listen(port, () => {

--- a/src/servers/spotlight/state.mjs
+++ b/src/servers/spotlight/state.mjs
@@ -1,0 +1,3 @@
+export let state = {
+	status: {}
+};


### PR DESCRIPTION
PR to introduce the boilerplate for a fastify server and a single
endpoint, meant to test the status of the provisioned instances created
by the Terraform server.

- `down` (no resources provisioned)
- `scheduling` (resources have been provisioned using Terraform, but the
  instances aren't ready yet)
- `ready` (resources provisioned, return number of resources
  provisioned)

The PR also needs to set up status endpoints for the Terraform server,
seeing as this is where we can set status state depending on where in
the process order the execution is. The endpoints are the same, as
above, except that instead of `ready`, we use `up`, indicating that the
EC2 instances are provisioned and ready to recieve HTTP communication,
despite the fact the the Spotlight containers themselves might not be
ready to recieve input. I've decided to implement it this way as it
separates concerns - Terraform server is responsible for provision,
whereas Spotlight/Annotation server is responsible for annotation, and
therefore shouldn't be considered `ready` or `up` until the containers
are. Using `up` vs. `ready` helps distinguish these two states.

closes #130