### PR TITLE
Script to generate graph csv from DBpedia entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"commander": "^9.0.0",
 				"cors": "^2.8.5",
 				"cross-env": "^7.0.3",
+				"csv-stringify": "^6.2.0",
 				"express": "^4.18.1",
 				"fastify": "^4.2.1",
 				"lamb": "^0.60.0",
@@ -2438,6 +2439,11 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/csv-stringify": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.2.0.tgz",
+			"integrity": "sha512-dcUbQLRTTDcgQxgEU8V9IctkaCwHZjZfzUZ5ZB3RY8Y+pXtdtl5iVQHfGzANytFFkRKanYzBXrkfpNdGR7eviA=="
 		},
 		"node_modules/d3-dsv": {
 			"version": "2.0.0",
@@ -6909,6 +6915,11 @@
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
 			}
+		},
+		"csv-stringify": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.2.0.tgz",
+			"integrity": "sha512-dcUbQLRTTDcgQxgEU8V9IctkaCwHZjZfzUZ5ZB3RY8Y+pXtdtl5iVQHfGzANytFFkRKanYzBXrkfpNdGR7eviA=="
 		},
 		"d3-dsv": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"commander": "^9.0.0",
 		"cors": "^2.8.5",
 		"cross-env": "^7.0.3",
+		"csv-stringify": "^6.2.0",
 		"express": "^4.18.1",
 		"fastify": "^4.2.1",
 		"lamb": "^0.60.0",

--- a/src/bin/es/graph.mjs
+++ b/src/bin/es/graph.mjs
@@ -1,0 +1,51 @@
+import { createWriteStream } from 'fs';
+
+import { Presets, SingleBar } from 'cli-progress';
+import { Command } from 'commander';
+import { stringify } from 'csv-stringify/sync';
+import * as _ from 'lamb';
+
+import { arxliveCopy } from 'conf/config.mjs';
+import { count } from 'es/index.mjs';
+import { scroll, clearScroll } from 'es/search.mjs';
+
+const program = new Command();
+
+program
+.command('csv')
+.description('Creates a csv from an ES index representing a DBpedia entities graph.')
+.argument('<inputIndex>', 'Input index name')
+.argument('<outputPath>', 'Path to output the csv.')
+.argument('[domain]', 'domain on which to create index', arxliveCopy)
+.action(async (index, path, domain) => {
+	const writer = createWriteStream(path);
+	const scroller = scroll(domain, index, { size: 1000, });
+	const total = await count(domain, index);
+	const bar = new SingleBar(Presets.rect);
+
+	const headers = ['sourceNode', 'abstractNode', 'confidence'];
+	writer.write(stringify([headers]));
+	bar.start(total, 0);
+
+	let page;
+	for await (page of scroller) {
+		const nodes = _.flatMap(
+			page.hits.hits,
+			({ _source: doc }) => {
+			    const edges = _.map(
+				    doc.dbpedia_entities || [],
+				    entity => [doc.URI, entity.URI, entity.confidence]
+			    );
+			    return edges;
+			}
+		);
+		bar.increment(page.hits.hits.length);
+		writer.write(stringify(nodes));
+	}
+	if (page) {
+		clearScroll(domain, page._scroll_id);
+	}
+	bar.stop();
+});
+
+program.parse();

--- a/src/bin/neo4j/load_csv.cypher
+++ b/src/bin/neo4j/load_csv.cypher
@@ -1,0 +1,14 @@
+// files on linux system must be copied to /var/lib/neo4j/import for below to work
+:param path => 'file:///<your_csv_file_here>';
+CREATE INDEX URI_index IF NOT EXISTS FOR (n:Entity) ON (n.URI);
+
+LOAD CSV WITH HEADERS FROM $path AS row
+MERGE (a:Entity {URI: row.sourceNode, isSource: true});
+
+LOAD CSV WITH HEADERS FROM $path AS row
+MERGE (b:Entity {URI: row.abstractNode, isSource: false});
+
+LOAD CSV WITH HEADERS FROM $path AS row
+MATCH (a:Entity {URI: row.sourceNode})
+MATCH (b:Entity {URI: row.abstractNode})
+CREATE (a)<-[r:APPEARS_IN_ABSTRACT {confidence: toInteger(row.confidence)}]-(b);


### PR DESCRIPTION
Creates a csv for the nodes created when annotating entities and their
DBpedia abstracts.
Also includes cypher script to ingest the resulting csv data into
a neo4j database.

closes #140