### PR TITLE
Logic for counting confidence values for entities

### DIFF
--- a/src/node_modules/es/entities.mjs
+++ b/src/node_modules/es/entities.mjs
@@ -34,3 +34,38 @@ export const getEntities = async(
 	const entities = _.keys(uriCounts);
 	return entities;
 };
+
+/**
+ * @function getAllConfidenceLevels
+ * @description counts the different confidence values found for every unique entity on a given ES index.
+ * @param {string} index Index on which to count confidence levels
+ * @param {string} domain Domain on which the index sits
+ * @returns { Object.<string, number[]> } an object where keys are the unique
+ * entity URIs and values are an array of confidence values found for that entity.
+ */
+export const getAllConfidenceLevels = async(
+	index,
+	domain=arxliveCopy
+) => {
+	const scroller = scroll(domain, index, { size: 10000, });
+	const confidenceCounts = {};
+	let page;
+	for await (page of scroller) {
+		const entities = _.flatMap(
+			page.hits.hits,
+			_.getPath('_source.dbpedia_entities')
+		);
+		_.forEach(
+			entities,
+			({ URI, confidence }) => {
+				confidenceCounts[URI] = URI in confidenceCounts
+					? [ ...confidenceCounts[URI], confidence ]
+					: [ confidence ];
+			}
+		);
+	}
+	if (page) {
+		clearScroll(domain, page._scroll_id);
+	}
+	return confidenceCounts;
+};


### PR DESCRIPTION
Counts confidence values for all unique entities on a given ES index.

closes #155