### PR TITLE
Retrieve DBpedia classes

### DIFF
--- a/src/node_modules/dbpedia/ontology.mjs
+++ b/src/node_modules/dbpedia/ontology.mjs
@@ -1,0 +1,22 @@
+import { promises as fs } from 'fs';
+
+import { stringify } from '@svizzle/utils';
+import * as _ from 'lamb';
+
+import { dbo } from 'dbpedia/util.mjs';
+
+const FILE_ONTOLOGY_JSON = 'data/dbpedia/ontology.json';
+
+export const loadOntology = async (depth, { squash=false, fullURI=true }={}) => {
+	const data = await fs.readFile(FILE_ONTOLOGY_JSON, { encoding: 'utf-8'});
+	const changedURIs = fullURI
+		? JSON.parse(data)
+		: JSON.parse(data.replaceAll(dbo, ''));
+
+	const selectAtDepth = _.pickIf(value => _.getIn(value, 'depth') <= depth);
+	const ontology = squash
+		? _.values(_.mapValues(selectAtDepth(changedURIs), _.getKey('class_')))
+		: selectAtDepth(changedURIs);
+
+	return ontology;
+};

--- a/src/node_modules/dbpedia/requests.mjs
+++ b/src/node_modules/dbpedia/requests.mjs
@@ -1,6 +1,8 @@
 import * as _ from 'lamb';
 
 import { getValue, isIterableLongerThan1 } from '@svizzle/utils';
+
+import { loadOntology } from 'dbpedia/ontology.mjs';
 import { dbr, prefixes } from 'dbpedia/util.mjs';
 import { query } from 'sparql/query.mjs';
 
@@ -89,20 +91,66 @@ export const getEntityAbstract = input => {
 };
 
 export const isDisambiguation = async input => {
-	const sanitizedURIs = sanitizeInput(input);
-	const queries = _.map(sanitizedURIs, URI =>
-		`{
-			BIND (${URI} as ?title)
-			OPTIONAL { ${URI} dbo:wikiPageDisambiguates ?resource . }
-		}`,
-	);
-	const sparql = buildQuery(queries);
-	const results = await makeRequest(sparql);
-	const groups = _.group(results, _.getKey('title'));
+	const template = `{
+		BIND ($$URI$$ as ?title)
+		OPTIONAL { $$URI$$ dbo:wikiPageDisambiguates ?resource . }
+	}`;
+	const values = await genericRequest(input, template);
+	const groups = _.group(values, _.getKey('title'));
 
 	// if the dbo:wikiPageDisambiguates predicate returns at least one value
 	// for the URI, then it's a disambiguation page. As the title binding
 	// will always be found, we check for length > 1
 	const disambiguations = _.mapValues(groups, isIterableLongerThan1);
 	return disambiguations;
+};
+
+export const getClasses = async (
+	input,
+	{
+		depth=Infinity,
+		squash=true,
+		fullURI=true
+	} = {}
+) => {
+
+	const template = `{
+			BIND ($$URI$$ as ?title)
+			OPTIONAL { $$URI$$ rdf:type ?type . }
+	}`;
+	const values = await genericRequest(input, template);
+	const groups = _.group(values, _.getKey('title'));
+	const types = _.mapValues(groups, group => _.map(group, _.getKey('type')));
+	const classFilter = await loadOntology(depth);
+	const filteredTypes = _.mapValues(
+		types,
+		typeList => {
+			const filtered = _.filter(typeList, t => t in classFilter);
+			const squashed = squash
+				? filtered
+				: _.map(filtered, key => _.getIn(classFilter, key));
+			const URIs = fullURI
+				? squashed
+				: JSON.parse(stringify(squashed).replaceAll(dbo, ''));
+			return URIs;
+		}
+	);
+	return filteredTypes;
+};
+
+export const hasInfoBoxTemplate = async input => {
+	const template = `{
+			BIND ($$URI$$ as ?URI)
+			OPTIONAL { $$URI$$ dbp:wikiPageUsesTemplate ?template . }
+	}`;
+	const values = await genericRequest(input, template);
+	const groups = _.group(values, _.getKey('URI'));
+	const wikiTemplates = _.mapValues(groups, _.pluck('template'));
+	const infobox =  'http://dbpedia.org/resource/Template:Infobox';
+
+	const results = _.mapValues(
+		wikiTemplates,
+		_.some(t => (t || '').startsWith(infobox))
+	);
+	return results;
 };


### PR DESCRIPTION
Uses the rdf:type predicate and the dbp:wikiPageUsesTemplate along with some SPARQL to retrieve class data for given DBpedia entities.

closes #157