### PR TITLE
Script for copying an s3 bucket to an ES index

### DIFF
--- a/src/bin/s3/bucketToIndex.mjs
+++ b/src/bin/s3/bucketToIndex.mjs
@@ -1,0 +1,66 @@
+import { Command, Option } from 'commander';
+import * as _ from 'lamb';
+
+import { streamArray, streamObject } from 'aws/s3.mjs';
+import { arxliveCopy } from 'conf/config.mjs';
+import { bulkRequest } from 'es/bulk.mjs';
+import { createIndex } from 'es/index.mjs';
+import { commanderParseInt } from 'util/commander.mjs';
+
+const program = new Command();
+program.option(
+	'-d, --domain <domain>',
+	'ES domain on which the index is held',
+	arxliveCopy
+);
+program.option(
+	'-c, --chunk-size <bytes>',
+	'number of bytes to chunk with',
+	commanderParseInt
+);
+program.addOption(
+	new Option('--format <format>')
+	.choices(['array', 'object'])
+	.default('object')
+);
+program.requiredOption('-i, --index <index>', 'name of index');
+program.requiredOption('-b, --bucket <bucket name>', 'name of s3 bucket');
+program.requiredOption('-k, --key <bucket key>', 'name of s3 key');
+program.parse();
+
+const options = program.opts();
+const formatObject = _.pipe([
+	_.pairs,
+	_.mapWith(([key, value]) => ({ _id: key, data: { value } }))
+]);
+const formatArray = _.mapWith(
+	({ id, ...rest }) => ({ _id: id, data: rest })
+);
+
+const funcs = {
+	'object': [streamObject, formatObject],
+	'array': [streamArray, formatArray]
+};
+
+const main = async () => {
+
+	await createIndex(options.index, options.domain);
+	const [stream, formatter] = funcs[options.format];
+	const streamer = stream(
+		options.bucket,
+		options.key,
+		{ increment: options.chunkSize }
+	);
+
+	for await (let docs of streamer) {
+		const bulkFormat = formatter(docs);
+		await bulkRequest(
+			options.domain,
+			options.index,
+			bulkFormat,
+			'create'
+		);
+	}
+};
+
+await main();

--- a/src/node_modules/aws/s3.mjs
+++ b/src/node_modules/aws/s3.mjs
@@ -1,0 +1,115 @@
+import { S3Client, GetObjectCommand, GetObjectAttributesCommand } from "@aws-sdk/client-s3";
+import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import * as cliProgress from 'cli-progress';
+
+import * as _ from 'lamb';
+
+const config = {
+	credentials: defaultProvider(),
+	region: 'eu-west-2',
+};
+const client = new S3Client(config);
+
+const parseMost = (chunk, type) => {
+	const [ start, end ] = type === 'object' ? ['{', '}'] : ['[', ']'];
+	for (let i = chunk.length - 1; i >= 0; i--) {
+		if (chunk[i] === ',' || chunk[i] === end) {
+			const test = `${start}${_.slice(chunk, 0, i).join('')}${end}`;
+			try {
+				const documents = JSON.parse(test);
+				return { documents, index: i+1};
+			} catch {}
+		}
+	}
+	return { documents: null, index: -1 };
+};
+
+const getObject = (bucket, key, { start=0, end=-1 }={}) => {
+	return new Promise(async (resolve, error) => {
+		const get = new GetObjectCommand({
+			Bucket: bucket,
+			Key: key,
+			Range: `bytes=${start}-${end}`
+		});
+		const { Body, ContentLength } = await client.send(get);
+		const finished = end === -1 || ContentLength < end - start;
+		const data = [];
+		Body.on('error', err => error(err));
+		Body.on('data', chunk => data.push(chunk));
+		Body.on('end', () => resolve({data: data.join(''), finished}));
+	});
+};
+
+const getObjectAttributes = async(
+	bucket,
+	key,
+	attributeList=['ETag', 'Checksum', 'ObjectParts', 'StorageClass',  'ObjectSize']
+) => {
+	const get = new GetObjectAttributesCommand({
+		Bucket: bucket,
+		Key: key,
+		ObjectAttributes: attributeList
+	});
+	const attributes = await client.send(get);
+	return attributes;
+};
+
+async function *stream(
+	bucket,
+	key,
+	type,
+	{ increment=64_000 }={}
+) {
+	let current = 0;
+	let chunk, finished;
+	let data = '';
+
+	// check at very beginning that types match up
+	const { data: first } = await getObject(
+		bucket, key, { start: 0, end: 0 }
+	);
+	if (
+		first === '{' && type !== 'object' ||
+		first === '[' && type !== 'array' ||
+		first !== '{' && first !== '[') {
+		throw new Error(
+			`Type errror. Are you sure the bucket object\'s type is correct?`
+		);
+	}
+
+	const { ObjectSize: size } = await getObjectAttributes(bucket, key);
+	const bar = new cliProgress.SingleBar(cliProgress.Presets.shades_classic);
+	bar.start(size, 0);
+	do {
+
+		// always omit first byte, as we know it's either '{' or '['
+		// eslint-disable-next-line no-await-in-loop
+		({ data: chunk, finished } = await getObject(
+			bucket, key, { start: current+1, end: current + increment }
+		));
+		data += chunk;
+		const { documents, index } = parseMost(data, type);
+		if (documents) {
+			yield documents;
+			data = '';
+			current += index;
+		} else {
+			current += increment;
+		}
+		bar.update(current);
+	} while (!finished);
+	bar.update(size);
+	bar.stop();
+}
+
+export const streamObject = (
+	bucket,
+	key,
+	{ increment=64_000 }={}
+) => stream(bucket, key, 'object', { increment });
+
+export const streamArray = (
+	bucket,
+	key,
+	{ increment=64_000 }={}
+) => stream(bucket, key, 'array', { increment });


### PR DESCRIPTION
Uses range requests to stream bytes from specified bucket/object pair,
then uses the ES bulk API to create documents.

closes https://github.com/nestauk/dap_dv_backends/issues/162