### PR TITLE
ETL for indexToBucket script

### DIFF
--- a/src/bin/s3/indexToBucket.mjs
+++ b/src/bin/s3/indexToBucket.mjs
@@ -1,13 +1,18 @@
-import { S3Client, CreateMultipartUploadCommand, UploadPartCommand, CompleteMultipartUploadCommand } from "@aws-sdk/client-s3";
-import { defaultProvider } from "@aws-sdk/credential-provider-node";
 import * as cliProgress from 'cli-progress';
-import { Command, CommanderError } from 'commander';
+import { Command, Option } from 'commander';
 import * as _ from 'lamb';
 
+import {
+	initialiseMultiPartUpload,
+	uploadPart,
+	completeMultiPartUpload,
+	MIN_PART_SIZE
+} from 'aws/s3.mjs';
 import { arxliveCopy } from 'conf/config.mjs';
 import { scroll } from 'es/search.mjs';
 import { count } from 'es/index.mjs';
 import { commanderParseInt } from 'util/commander.mjs';
+import { stringify } from '@svizzle/utils';
 
 const program = new Command();
 program.option(
@@ -25,83 +30,161 @@ program.option(
 	10000
 );
 program.option(
+	'-t, --threshold <confidence value>',
+	'Threshold to filter with',
+	commanderParseInt,
+	0
+);
+program.option(
 	'-n, --pages <number of pages>',
 	'Number of pages to iterate',
 	'all'
+);
+program.addOption(
+	new Option('--format <format>')
+	.choices(['array', 'object', 'entities'])
+	.default('array')
+);
+program.addOption(
+	new Option('--processor <processor>')
+	.choices(['default', 'simple', 'es'])
+	.default('default')
 );
 
 program.parse();
 const options = program.opts();
 
-const config = {
-	credentials: defaultProvider(),
-	region: 'eu-west-2',
+const separate = (start, stop, data, page, total) => {
+	let raw = JSON.stringify(data).slice(1, -1);
+	if (page === 1) {
+		raw = `${start}${raw}`;
+	}
+	if (page === total) {
+		raw = `${raw}${stop}`;
+	} else {
+		raw = `${raw},`;
+	}
+	return raw;
 };
-const client = new S3Client(config);
+
+const arrayFormatter = (data, page, total) => {
+	return separate('[', ']', data, page, total);
+};
+
+const objectFormatter = (data, page, total, { key=null }={}) => {
+
+	const getter = key ? _.getPath(key) : _.identity;
+	const documents = _.reduce(
+		data,
+		(acc, doc) => {
+			acc[doc._id] = getter(doc);
+			return acc;
+		},
+		{}
+	);
+	return separate('{', '}', documents, page, total);
+};
+
+const entitiesFormatter = (data, page, total) =>
+	objectFormatter(data, page, total, { key: '_source.dbpedia_entities' });
+
+const extractSource = _.mapWith(_.getKey('_source'));
+
+const extractURIandConfidence = _.mapWith(
+	doc => {
+		doc.dbpedia_entities = _.map(
+			doc.dbpedia_entities,
+			entity => ({ URI: entity.URI, confidence: entity.confidence })
+		);
+		return doc;
+	}
+);
+
+const filterByConfidence = threshold => _.mapWith(
+	doc => {
+		doc._source.dbpedia_entities = _.filter(
+			doc._source.dbpedia_entities || [],
+			entity => entity.confidence > threshold
+		);
+		return doc;
+	}
+);
+
+const formats = {
+	array: arrayFormatter,
+	object: objectFormatter,
+	entities: entitiesFormatter
+};
+
+const processors = {
+	es: _.identity,
+	default: extractSource,
+	simple: _.pipe([extractSource, extractURIandConfidence])
+};
 
 const main = async () => {
-	const create = new CreateMultipartUploadCommand({
-		Bucket: options.bucket,
-		Key: options.key
-	});
-	const { UploadId } = await client.send(create);
+
+	const filter = filterByConfidence(options.threshold);
+	const processor = processors[options.processor];
+	const etl = _.pipe([filter, processor]);
+	const formatter = formats[options.format];
 
 	const scroller = scroll(options.domain, options.index, {
 		size: options.pageSize,
 		pages: options.pages
 	});
 
-	const bar = new cliProgress.SingleBar(
-		cliProgress.Presets.shades_classic
-	);
 	const totalDocuments = await count(options.domain, options.index);
 	const totalWork = options.pages === 'all'
 		? totalDocuments
 		: options.pages * options.pageSize;
-	const pages = options.pages === 'all'
-		? Math.floor(totalDocuments / options.pages)
-		: Math.floor(Math.min(totalDocuments, options.pages * options.pageSize) / options.pages);
 
+	const pagesNeeded = Math.floor(totalDocuments / options.pageSize) + 1;
+	const pages = options.pages === 'all'
+		? pagesNeeded
+		: Math.min(pagesNeeded, options.pages);
+
+	const bar = new cliProgress.SingleBar(
+		cliProgress.Presets.shades_classic
+	);
+
+	const uploadId = await initialiseMultiPartUpload(options.bucket, options.key);
 	bar.start(totalWork, 0);
 
-	let PartNumber = 1;
-	let Parts = [];
+	let partNumber = 1;
+	let currentPage = 1;
+	let parts = [];
+	let chunk = '';
 
 	for await (let page of scroller) {
-		const data = page.hits.hits;
-		let raw = JSON.stringify(data).slice(1, -1);
-		if (PartNumber === 1) {
-			raw = `[${raw},`;
-		} else if (PartNumber === pages) {
-			raw = `${raw}]`;
-		} else {
-			raw = `${raw},`;
-		}
+		const data = etl(page.hits.hits);
+		const raw = formatter(data, currentPage, pages);
+		chunk += raw;
 
-		const upload = new UploadPartCommand({
-			Body: raw,
-			Bucket: options.bucket,
-			Key: options.key,
-			UploadId,
-			PartNumber
-		});
-		const { ETag } = await client.send(upload);
-		Parts.push({ PartNumber, ETag });
-		PartNumber++;
-		bar.increment(options.pageSize);
+		// check if the chunk is large enough to upload as a part to s3
+		if (Buffer.byteLength(chunk) >= MIN_PART_SIZE) {
+			const ETag = await uploadPart(
+				chunk, options.bucket, options.key, uploadId, partNumber
+			);
+			parts.push({ PartNumber: partNumber, ETag });
+			partNumber++;
+			chunk = '';
+		}
+		bar.increment(page.hits.hits.length);
+		currentPage++;
 	}
 
+	// if chunk as not been reset on last iteration, there's still one last
+	// upload to perform
+	if (chunk.length) {
+		const ETag = await uploadPart(
+			chunk, options.bucket, options.key, uploadId, partNumber
+		);
+		parts.push({ PartNumber: partNumber, ETag });
+		partNumber++;
+	}
+	await completeMultiPartUpload(options.bucket, options.key, parts, uploadId);
 	bar.stop();
-
-	const complete = new CompleteMultipartUploadCommand({
-		Bucket: options.bucket,
-		Key: options.key,
-		MultipartUpload: { Parts },
-		UploadId
-	});
-	const completeResponse = await client.send(complete);
-	console.log(completeResponse);
-
 };
 
 await main();

--- a/src/node_modules/aws/s3.mjs
+++ b/src/node_modules/aws/s3.mjs
@@ -1,8 +1,11 @@
-import { S3Client, GetObjectCommand, GetObjectAttributesCommand } from "@aws-sdk/client-s3";
+import { S3Client, GetObjectCommand, GetObjectAttributesCommand, CreateMultipartUploadCommand, UploadPartCommand, CompleteMultipartUploadCommand } from "@aws-sdk/client-s3";
 import { defaultProvider } from "@aws-sdk/credential-provider-node";
 import * as cliProgress from 'cli-progress';
 
 import * as _ from 'lamb';
+
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+export const MIN_PART_SIZE = 5242880;
 
 const config = {
 	credentials: defaultProvider(),
@@ -113,3 +116,47 @@ export const streamArray = (
 	key,
 	{ increment=64_000 }={}
 ) => stream(bucket, key, 'array', { increment });
+
+export const initialiseMultiPartUpload = async (bucket, key) => {
+	const create = new CreateMultipartUploadCommand({
+		Bucket: bucket,
+		Key: key
+	});
+	const { UploadId: uploadId } = await client.send(create);
+	return uploadId;
+};
+
+export const uploadPart = async (
+	data,
+	bucket,
+	key,
+	uploadId,
+	partNumber
+) => {
+	const upload = new UploadPartCommand({
+		Body: data,
+		Bucket: bucket,
+		Key: key,
+		UploadId: uploadId,
+		PartNumber: partNumber
+	});
+
+	const { ETag } = await client.send(upload);
+	return ETag;
+};
+
+export const completeMultiPartUpload = async (
+	bucket,
+	key,
+	parts,
+	uploadId
+) => {
+	const complete = new CompleteMultipartUploadCommand({
+		Bucket: bucket,
+		Key: key,
+		MultipartUpload: { Parts: parts },
+		UploadId: uploadId
+	});
+	const completeResponse = await client.send(complete);
+	return completeResponse;
+};


### PR DESCRIPTION
Adds formatters and preprocessors for the indexToBucket script.
Also allows for filtering of entity values based on confidence.

closes https://github.com/nestauk/dap_dv_backends/issues/163