### PR TITLE
Integrate s3 logic, expose as endpoint

### DIFF
--- a/src/bin/s3/bucketToIndex.mjs
+++ b/src/bin/s3/bucketToIndex.mjs
@@ -1,10 +1,8 @@
 import { Command, Option } from 'commander';
 import * as _ from 'lamb';
 
-import { streamArray, streamObject } from 'aws/s3.mjs';
+import { bucketToIndex } from 'aws/s3.mjs';
 import { arxliveCopy } from 'conf/config.mjs';
-import { bulkRequest } from 'es/bulk.mjs';
-import { createIndex } from 'es/index.mjs';
 import { commanderParseInt } from 'util/commander.mjs';
 
 const program = new Command();
@@ -16,12 +14,18 @@ program.option(
 program.option(
 	'-c, --chunk-size <bytes>',
 	'number of bytes to chunk with',
-	commanderParseInt
+	commanderParseInt,
+	512_000,
+);
+program.option(
+	'-f, --id-field <field>',
+	'Name of field to use as id',
+	null
 );
 program.addOption(
 	new Option('--format <format>')
 	.choices(['array', 'object'])
-	.default('object')
+	.default('array')
 );
 program.requiredOption('-i, --index <index>', 'name of index');
 program.requiredOption('-b, --bucket <bucket name>', 'name of s3 bucket');
@@ -29,38 +33,17 @@ program.requiredOption('-k, --key <bucket key>', 'name of s3 key');
 program.parse();
 
 const options = program.opts();
-const formatObject = _.pipe([
-	_.pairs,
-	_.mapWith(([key, value]) => ({ _id: key, data: { value } }))
-]);
-const formatArray = _.mapWith(
-	({ id, ...rest }) => ({ _id: id, data: rest })
-);
-
-const funcs = {
-	'object': [streamObject, formatObject],
-	'array': [streamArray, formatArray]
-};
 
 const main = async () => {
-
-	await createIndex(options.index, options.domain);
-	const [stream, formatter] = funcs[options.format];
-	const streamer = stream(
+	await bucketToIndex(
+		options.index,
+		options.domain,
 		options.bucket,
 		options.key,
-		{ increment: options.chunkSize }
+		options.idField,
+		options.format,
+		options.chunkSize
 	);
-
-	for await (let docs of streamer) {
-		const bulkFormat = formatter(docs);
-		await bulkRequest(
-			options.domain,
-			options.index,
-			bulkFormat,
-			'create'
-		);
-	}
 };
 
 await main();

--- a/src/bin/s3/indexToBucket.mjs
+++ b/src/bin/s3/indexToBucket.mjs
@@ -1,18 +1,9 @@
-import * as cliProgress from 'cli-progress';
 import { Command, Option } from 'commander';
 import * as _ from 'lamb';
 
-import {
-	initialiseMultiPartUpload,
-	uploadPart,
-	completeMultiPartUpload,
-	MIN_PART_SIZE
-} from 'aws/s3.mjs';
+import { indexToBucket } from 'aws/s3.mjs';
 import { arxliveCopy } from 'conf/config.mjs';
-import { scroll } from 'es/search.mjs';
-import { count } from 'es/index.mjs';
 import { commanderParseInt } from 'util/commander.mjs';
-import { stringify } from '@svizzle/utils';
 
 const program = new Command();
 program.option(
@@ -54,137 +45,19 @@ program.addOption(
 program.parse();
 const options = program.opts();
 
-const separate = (start, stop, data, page, total) => {
-	let raw = JSON.stringify(data).slice(1, -1);
-	if (page === 1) {
-		raw = `${start}${raw}`;
-	}
-	if (page === total) {
-		raw = `${raw}${stop}`;
-	} else {
-		raw = `${raw},`;
-	}
-	return raw;
-};
-
-const arrayFormatter = (data, page, total) => {
-	return separate('[', ']', data, page, total);
-};
-
-const objectFormatter = (data, page, total, { key=null }={}) => {
-
-	const getter = key ? _.getPath(key) : _.identity;
-	const documents = _.reduce(
-		data,
-		(acc, doc) => {
-			acc[doc._id] = getter(doc);
-			return acc;
-		},
-		{}
-	);
-	return separate('{', '}', documents, page, total);
-};
-
-const entitiesFormatter = (data, page, total) =>
-	objectFormatter(data, page, total, { key: '_source.dbpedia_entities' });
-
-const extractSource = _.mapWith(_.getKey('_source'));
-
-const extractURIandConfidence = _.mapWith(
-	doc => {
-		doc.dbpedia_entities = _.map(
-			doc.dbpedia_entities,
-			entity => ({ URI: entity.URI, confidence: entity.confidence })
-		);
-		return doc;
-	}
-);
-
-const filterByConfidence = threshold => _.mapWith(
-	doc => {
-		doc._source.dbpedia_entities = _.filter(
-			doc._source.dbpedia_entities || [],
-			entity => entity.confidence > threshold
-		);
-		return doc;
-	}
-);
-
-const formats = {
-	array: arrayFormatter,
-	object: objectFormatter,
-	entities: entitiesFormatter
-};
-
-const processors = {
-	es: _.identity,
-	default: extractSource,
-	simple: _.pipe([extractSource, extractURIandConfidence])
-};
 
 const main = async () => {
-
-	const filter = filterByConfidence(options.threshold);
-	const processor = processors[options.processor];
-	const etl = _.pipe([filter, processor]);
-	const formatter = formats[options.format];
-
-	const scroller = scroll(options.domain, options.index, {
-		size: options.pageSize,
-		pages: options.pages
-	});
-
-	const totalDocuments = await count(options.domain, options.index);
-	const totalWork = options.pages === 'all'
-		? totalDocuments
-		: options.pages * options.pageSize;
-
-	const pagesNeeded = Math.floor(totalDocuments / options.pageSize) + 1;
-	const pages = options.pages === 'all'
-		? pagesNeeded
-		: Math.min(pagesNeeded, options.pages);
-
-	const bar = new cliProgress.SingleBar(
-		cliProgress.Presets.shades_classic
+	await indexToBucket(
+		options.index,
+		options.domain,
+		options.bucket,
+		options.key,
+		options.threshold,
+		options.pages,
+		options.pageSize,
+		options.format,
+		options.processor
 	);
-
-	const uploadId = await initialiseMultiPartUpload(options.bucket, options.key);
-	bar.start(totalWork, 0);
-
-	let partNumber = 1;
-	let currentPage = 1;
-	let parts = [];
-	let chunk = '';
-
-	for await (let page of scroller) {
-		const data = etl(page.hits.hits);
-		const raw = formatter(data, currentPage, pages);
-		chunk += raw;
-
-		// check if the chunk is large enough to upload as a part to s3
-		if (Buffer.byteLength(chunk) >= MIN_PART_SIZE) {
-			const ETag = await uploadPart(
-				chunk, options.bucket, options.key, uploadId, partNumber
-			);
-			parts.push({ PartNumber: partNumber, ETag });
-			partNumber++;
-			chunk = '';
-		}
-		bar.increment(page.hits.hits.length);
-		currentPage++;
-	}
-
-	// if chunk as not been reset on last iteration, there's still one last
-	// upload to perform
-	if (chunk.length) {
-		const ETag = await uploadPart(
-			chunk, options.bucket, options.key, uploadId, partNumber
-		);
-		parts.push({ PartNumber: partNumber, ETag });
-		partNumber++;
-	}
-	await completeMultiPartUpload(options.bucket, options.key, parts, uploadId);
-	bar.stop();
 };
 
 await main();

--- a/src/node_modules/aws/s3.mjs
+++ b/src/node_modules/aws/s3.mjs
@@ -1,8 +1,13 @@
-import { S3Client, GetObjectCommand, GetObjectAttributesCommand, CreateMultipartUploadCommand, UploadPartCommand, CompleteMultipartUploadCommand } from "@aws-sdk/client-s3";
+import { S3Client, GetObjectCommand, GetObjectAttributesCommand, CreateMultipartUploadCommand, UploadPartCommand, CompleteMultipartUploadCommand, SelectParameters } from "@aws-sdk/client-s3";
 import { defaultProvider } from "@aws-sdk/credential-provider-node";
 import * as cliProgress from 'cli-progress';
 
 import * as _ from 'lamb';
+
+import { bulkRequest } from 'es/bulk.mjs';
+import { scroll } from 'es/search.mjs';
+import { count, createIndex } from 'es/index.mjs';
+
 
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
 export const MIN_PART_SIZE = 5242880;
@@ -20,11 +25,12 @@ const parseMost = (chunk, type) => {
 			const test = `${start}${_.slice(chunk, 0, i).join('')}${end}`;
 			try {
 				const documents = JSON.parse(test);
-				return { documents, index: i+1};
+				const leftover = _.slice(chunk, i+1, chunk.length).join('');
+				return { documents, leftover };
 			} catch {}
 		}
 	}
-	return { documents: null, index: -1 };
+	return { documents: null, leftover: chunk };
 };
 
 const getObject = (bucket, key, { start=0, end=-1 }={}) => {
@@ -61,7 +67,7 @@ async function *stream(
 	bucket,
 	key,
 	type,
-	{ increment=64_000 }={}
+	{ increment=512_000 }={}
 ) {
 	let current = 0;
 	let chunk, finished;
@@ -91,14 +97,12 @@ async function *stream(
 			bucket, key, { start: current+1, end: current + increment }
 		));
 		data += chunk;
-		const { documents, index } = parseMost(data, type);
+		const { documents, leftover } = parseMost(data, type);
 		if (documents) {
 			yield documents;
-			data = '';
-			current += index;
-		} else {
-			current += increment;
+			data = leftover;
 		}
+		current += increment;
 		bar.update(current);
 	} while (!finished);
 	bar.update(size);
@@ -159,4 +163,197 @@ export const completeMultiPartUpload = async (
 	});
 	const completeResponse = await client.send(complete);
 	return completeResponse;
+};
+
+
+export const bucketToIndex = async (
+	index,
+	domain,
+	bucket,
+	key,
+	idField=null,
+	format='array',
+	chunkSize=64_000,
+) => {
+
+	const method = idField ? 'create' : 'index';
+	const formatObject = _.pipe([
+		_.pairs,
+		_.mapWith(([k, value]) => ({ _id: k, data: { value } }))
+	]);
+	const formatArray = _.mapWith(
+		({ [idField]: id, ...rest }) => ({
+			...id && {id_: id},
+			data: rest
+		})
+	);
+	const funcs = {
+		object: [streamObject, formatObject],
+		array: [streamArray, formatArray]
+	};
+
+	await createIndex(index, domain);
+	const [stream_, formatter] = funcs[format];
+	const streamer = stream_(
+		bucket,
+		key,
+		{ increment: chunkSize }
+	);
+
+	for await (let docs of streamer) {
+		const bulkFormat = formatter(docs);
+		await bulkRequest(
+			domain,
+			index,
+			bulkFormat,
+			method
+		);
+	}
+};
+
+/* Index to Bucket Specific Functions */
+
+const separate = (start, stop, data, page, total) => {
+	let raw = JSON.stringify(data).slice(1, -1);
+	if (page === 1) {
+		raw = `${start}${raw}`;
+	}
+	if (page === total) {
+		raw = `${raw}${stop}`;
+	} else {
+		raw = `${raw},`;
+	}
+	return raw;
+};
+
+const arrayFormatter = (data, page, total) => {
+	return separate('[', ']', data, page, total);
+};
+
+const objectFormatter = (data, page, total, { key=null }={}) => {
+
+	const getter = key ? _.getPath(key) : _.identity;
+	const documents = _.reduce(
+		data,
+		(acc, doc) => {
+			acc[doc._id] = getter(doc);
+			return acc;
+		},
+		{}
+	);
+	return separate('{', '}', documents, page, total);
+};
+
+const entitiesFormatter = (data, page, total) =>
+	objectFormatter(data, page, total, { key: '_source.dbpedia_entities' });
+
+const extractSource = _.mapWith(_.getKey('_source'));
+
+const extractURIandConfidence = _.mapWith(
+	doc => {
+		doc.dbpedia_entities = _.map(
+			doc.dbpedia_entities,
+			entity => ({ URI: entity.URI, confidence: entity.confidence })
+		);
+		return doc;
+	}
+);
+
+const filterByConfidence = threshold => _.mapWith(
+	doc => {
+		if (doc._source.dbpedia_entities) {
+			doc._source.dbpedia_entities = _.filter(
+				doc._source.dbpedia_entities || [],
+				entity => entity.confidence > threshold
+			);
+		}
+		return doc;
+	}
+);
+
+export const indexToBucket = async(
+	index,
+	domain,
+	bucket,
+	key,
+	threshold=0,
+	pages='all',
+	pageSize=10000,
+	format='array',
+	processor='default'
+) => {
+
+	const formats = {
+		array: arrayFormatter,
+		object: objectFormatter,
+		entities: entitiesFormatter
+	};
+
+	const processors = {
+		es: _.identity,
+		default: extractSource,
+		simple: _.pipe([extractSource, extractURIandConfidence])
+	};
+
+	const filter = filterByConfidence(threshold);
+	const processor_ = processors[processor];
+	const etl = _.pipe([filter, processor_]);
+	const formatter = formats[format];
+
+	const scroller = scroll(domain, index, {
+		pages,
+		size: pageSize,
+	});
+
+	const totalDocuments = await count(domain, index);
+	const totalWork = pages === 'all'
+		? totalDocuments
+		: pages * pageSize;
+
+	const pagesNeeded = Math.floor(totalDocuments / pageSize) + 1;
+	const pages_ = pages === 'all'
+		? pagesNeeded
+		: Math.min(pagesNeeded, pages);
+
+	const bar = new cliProgress.SingleBar(
+		cliProgress.Presets.shades_classic
+	);
+
+	const uploadId = await initialiseMultiPartUpload(bucket, key);
+	bar.start(totalWork, 0);
+
+	let partNumber = 1;
+	let currentPage = 1;
+	let parts = [];
+	let chunk = '';
+
+	for await (let page of scroller) {
+		const data = etl(page.hits.hits);
+		const raw = formatter(data, currentPage, pages_);
+		chunk += raw;
+
+		// check if the chunk is large enough to upload as a part to s3
+		if (Buffer.byteLength(chunk) >= MIN_PART_SIZE) {
+			const ETag = await uploadPart(
+				chunk, bucket, key, uploadId, partNumber
+			);
+			parts.push({ PartNumber: partNumber, ETag });
+			partNumber++;
+			chunk = '';
+		}
+		bar.increment(page.hits.hits.length);
+		currentPage++;
+	}
+
+	// if chunk as not been reset on last iteration, there's still one last
+	// upload to perform
+	if (chunk.length) {
+		const ETag = await uploadPart(
+			chunk, bucket, key, uploadId, partNumber
+		);
+		parts.push({ PartNumber: partNumber, ETag });
+		partNumber++;
+	}
+	await completeMultiPartUpload(bucket, key, parts, uploadId);
+	bar.stop();
 };

--- a/src/node_modules/es/bulk.mjs
+++ b/src/node_modules/es/bulk.mjs
@@ -2,7 +2,6 @@ import { stringify } from '@svizzle/utils';
 import * as _ from 'lamb';
 
 import { buildRequest, makeRequest } from 'es/requests.mjs';
-import { saveObj } from '@svizzle/file';
 
 const generateBulkPayload = (method, index) => _.pipe([
 	_.flatMapWith(doc =>
@@ -49,13 +48,11 @@ export const bulkRequest = async (
 		{ payload, contentType: 'application/x-ndjson' }
 	);
 	const { body: response, code } = await makeRequest(request);
-	if (response.errors) {
-		const errors = _.filter(response.items, item => 'error' in item[method]);
-		const message = `Certain bulk requests failed:\n${stringify(errors)}`;
+	if (response.error) {
 		if (error) {
-			throw new Error(message);
+			throw new Error(stringify(response));
 		} else {
-			console.error(message);
+			console.error(stringify(response));
 		}
 	}
 	return { response, code };

--- a/src/services/annotation/service/progress.mjs
+++ b/src/services/annotation/service/progress.mjs
@@ -1,16 +1,24 @@
 import { performance } from 'perf_hooks';
 
 import { sendEmail } from 'aws/email.mjs';
+import { indexToBucket } from 'aws/s3.mjs';
 
 
 export const Progress = class {
-	constructor(total, email, id) {
+	constructor(
+		total, email, id,
+		index=null, domain=null, bucket=null, key=null
+	) {
 		this.total = total;
 		this.email = email;
 		this.id = id;
 		this.current = 0;
 		this.startTime = performance.now();
 		this.endTime = null;
+		this.index = index;
+		this.domain = domain;
+		this.bucket = bucket;
+		this.key = key;
 	}
 
 	increment(amount) {
@@ -43,5 +51,13 @@ export const Progress = class {
 			`Your annotation with id <code>${this.id}</code> has finished`,
 			'Annotation finished.'
 		);
+		if (this.bucket) {
+			indexToBucket(
+				this.index,
+				this.domain,
+				this.bucket,
+				this.key,
+			);
+		}
 	}
 };

--- a/src/services/annotation/service/routes.mjs
+++ b/src/services/annotation/service/routes.mjs
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
+import { bucketToIndex, indexToBucket } from 'aws/s3.mjs';
 import { arxliveCopy as DEFAULT_DOMAIN } from 'conf/config.mjs';
 import { count } from 'es/index.mjs';
 
@@ -7,6 +8,7 @@ import { MAX_WORKERS, annotationEndpoint } from '../config.mjs';
 import { annotationService } from './machine.mjs';
 import { Progress } from './progress.mjs';
 import { state } from './state.mjs';
+import { parseS3URI, uriToEsIndex } from './util.mjs';
 
 
 export const routes = (fastify, options, done) => {
@@ -24,6 +26,53 @@ export const routes = (fastify, options, done) => {
 			reply.send(state.progress[id].status());
 		}
 		reply.code(404).send({error: 'no annotation with that id found.'});
+	});
+
+	fastify.post('/annotate/s3', async (request, reply) => {
+
+		const domain = DEFAULT_DOMAIN;
+		let {
+			field,
+			email,
+			s3_input_uri,
+			s3_output_uri,
+			includeMetaData = true,
+			newField = 'dbpedia_entities',
+			workers = MAX_WORKERS,
+		} = request.body;
+
+		const id = uuidv4();
+		reply.send({ id });
+
+		const { bucket: inBucket, key: inKey } = parseS3URI(s3_input_uri);
+		const { bucket: outBucket, key: outKey } = parseS3URI(s3_output_uri);
+
+		const index = uriToEsIndex(s3_input_uri);
+		await bucketToIndex(
+			index,
+			domain,
+			inBucket,
+			inKey,
+		);
+
+		const total = await count(domain, index);
+		const progress = new Progress(total, email, id, index, domain, outBucket, outKey);
+		state.progress[id] = progress;
+
+		annotationService.send(
+			{
+				id,
+				workers,
+				domain,
+				index,
+				field,
+				newField,
+				annotationEndpoint,
+				includeMetaData,
+				progress,
+				type: 'PROVISION',
+			}
+		);
 	});
 
 	fastify.post('/annotate/es', async (request, reply) => {

--- a/src/services/annotation/service/util.mjs
+++ b/src/services/annotation/service/util.mjs
@@ -1,0 +1,12 @@
+export const parseS3URI = uri => {
+	const url = new URL(uri);
+	return {
+		bucket: url.host,
+		key: url.pathname.slice(1)
+	};
+};
+
+export const uriToEsIndex = uri => {
+	const { bucket, key } = parseS3URI(uri);
+	return `${bucket}.${key.replaceAll('/', '.')}`;
+};


### PR DESCRIPTION
Refactors existing s3 bucket scripts indexToBucket and bucketToIndex such that the logic is available from the generic node_modules dir. This then allows us to expose an `/annotate/s3` endpoint for the annotation service which will be used to annotate buckets. The logic being refactored in this PR is used to copy the contents of an s3 bucket to an ES index before then annotating as usual. Once the annotation has finished, we copy the index back to the specified output bucket.

closes #179