### PR TITLE
Protect annotation endpoints using authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"@aws-sdk/node-http-handler": "^3.49.0",
 				"@aws-sdk/protocol-http": "^3.49.0",
 				"@aws-sdk/signature-v4": "^3.49.0",
+				"@fastify/middie": "^8.0.0",
 				"@svizzle/file": "^0.12.0",
 				"@svizzle/utils": "^0.16.0",
 				"bcrypt": "^5.0.1",
@@ -1726,6 +1727,21 @@
 				"fast-json-stringify": "^5.0.0"
 			}
 		},
+		"node_modules/@fastify/middie": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.0.0.tgz",
+			"integrity": "sha512-SsZUzJwRV2IBhko8TNI5gGzUdUp2Xd0XCrU+pBTfsMN8LYGsksDI/Hb3qcUZ2/Kfg6ecbFEeRO4nZmHeFCDpHQ==",
+			"dependencies": {
+				"fastify-plugin": "^3.0.0",
+				"path-to-regexp": "^6.1.0",
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/@fastify/middie/node_modules/path-to-regexp": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+			"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.9.5",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -3032,6 +3048,11 @@
 				"semver": "^7.3.7",
 				"tiny-lru": "^8.0.2"
 			}
+		},
+		"node_modules/fastify-plugin": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
+			"integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA=="
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
@@ -6483,6 +6504,23 @@
 				"fast-json-stringify": "^5.0.0"
 			}
 		},
+		"@fastify/middie": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.0.0.tgz",
+			"integrity": "sha512-SsZUzJwRV2IBhko8TNI5gGzUdUp2Xd0XCrU+pBTfsMN8LYGsksDI/Hb3qcUZ2/Kfg6ecbFEeRO4nZmHeFCDpHQ==",
+			"requires": {
+				"fastify-plugin": "^3.0.0",
+				"path-to-regexp": "^6.1.0",
+				"reusify": "^1.0.4"
+			},
+			"dependencies": {
+				"path-to-regexp": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+					"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+				}
+			}
+		},
 		"@humanwhocodes/config-array": {
 			"version": "0.9.5",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -7481,6 +7519,11 @@
 				"semver": "^7.3.7",
 				"tiny-lru": "^8.0.2"
 			}
+		},
+		"fastify-plugin": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
+			"integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA=="
 		},
 		"fastq": {
 			"version": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"@aws-sdk/node-http-handler": "^3.49.0",
 		"@aws-sdk/protocol-http": "^3.49.0",
 		"@aws-sdk/signature-v4": "^3.49.0",
+		"@fastify/middie": "^8.0.0",
 		"@svizzle/file": "^0.12.0",
 		"@svizzle/utils": "^0.16.0",
 		"bcrypt": "^5.0.1",

--- a/src/services/annotation/config.mjs
+++ b/src/services/annotation/config.mjs
@@ -2,6 +2,7 @@ export const PORT = 4000;
 
 export const terraformServerAddress = "http://3.8.192.33";
 export const annotationEndpoint = new URL('annotate', terraformServerAddress);
+export const authenticationEndpoint = 'https://authentication.dap-tools.uk/authenticate';
 
 export const MAX_WORKERS=4;
 

--- a/src/services/annotation/service/app.mjs
+++ b/src/services/annotation/service/app.mjs
@@ -1,12 +1,21 @@
 import Fastify from 'fastify';
+import middie from '@fastify/middie';
 
 import { PORT } from '../config.mjs';
+import { authenticationMiddleware } from './middleware.mjs';
 import { routes } from './routes.mjs';
 
 const fastify = Fastify({
 	logger: true
 });
 
+/* midleware */
+await fastify.register(middie);
+
+// only authenticate annotate endpoints
+fastify.use('/annotate/(.*)', authenticationMiddleware);
+
+/* routes */
 fastify.register(routes);
 
 const start = async () => {

--- a/src/services/annotation/service/auth.mjs
+++ b/src/services/annotation/service/auth.mjs
@@ -1,0 +1,25 @@
+import { fetch } from 'undici';
+
+import { authenticationEndpoint } from '../config.mjs';
+
+export const authenticate = async (email, token) => {
+	const body = JSON.stringify({ email, token });
+	const response = await fetch(
+		authenticationEndpoint,
+		{
+			body,
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' }
+		}
+	);
+	const result = await response.json();
+	return result;
+};
+
+export const parseBasicAuth = header => {
+	const base64String = header.slice(6, -1);
+	const buff = Buffer.from(base64String, 'base64');
+	const utfString = buff.toString('utf-8');
+	const [ email, token ] = utfString.split(':');
+	return { email, token };
+};

--- a/src/services/annotation/service/middleware.mjs
+++ b/src/services/annotation/service/middleware.mjs
@@ -1,0 +1,39 @@
+import { authenticate, parseBasicAuth } from './auth.mjs';
+
+const respondWithAuthError = (res, message, code) => {
+	res.statusCode=401;
+	res.setHeader('Content-Type', 'application/json');
+	res.write(JSON.stringify({ error: message, code }));
+	res.end();
+};
+
+export const authenticationMiddleware = async(req, res, next) => {
+	if (!('authorization' in req.headers)) {
+		respondWithAuthError(
+			res,
+			'No Authorization Header set',
+			100
+		);
+		return;
+	}
+	const authHeader = req.headers.authorization;
+	if (!authHeader.startsWith('Basic')) {
+		respondWithAuthError(
+			res,
+			'Basic Authorization Header required',
+			101
+		);
+		return;
+	}
+	const { email, token } = parseBasicAuth(authHeader);
+	const isAuthorized = await authenticate(email, token);
+	if (!isAuthorized) {
+		respondWithAuthError(
+			res,
+			'Email and Token supplied cannot be authenticated',
+			102
+		);
+		return;
+	}
+	next();
+};


### PR DESCRIPTION
Implements some middleware which requires a Basic Authentication header on the annotation endpoints. The username is the Nesta email, the password is the token provided by the basic Email Authentication service.

closes #180