### PR TITLE
Change request type to send arrays of text

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+logs
+node_modules
+!/**/src/node_modules
+.prettierignore
+.DS_Store
+**/secrets/**
+src/services/**/terraform

--- a/src/bin/es/annotate.mjs
+++ b/src/bin/es/annotate.mjs
@@ -37,13 +37,19 @@ program.option(
 	'-p, --page-size <page size>',
 	'Size of page to scroll with',
 	commanderParseInt,
-	100
+	10000
 );
 program.option(
 	'-b, --batch-size <batch size>',
 	'Size of batch to annotate over',
 	commanderParseInt,
 	10
+);
+program.option(
+	'-g, --group-size <size>',
+	'Size of group of batches, usually corresponds to the number of worker nodes',
+	commanderParseInt,
+	4
 );
 program.option(
 	'-z, --pages <number of pages>',

--- a/src/node_modules/dbpedia/spotlight.mjs
+++ b/src/node_modules/dbpedia/spotlight.mjs
@@ -11,7 +11,7 @@ import { update } from 'es/update.mjs';
 import { scroll, clearScroll } from 'es/search.mjs';
 import { bulkRequest } from 'es/bulk.mjs';
 import { batch } from 'util/array.mjs';
-import { sleep } from 'util/time.mjs';
+import { logger } from 'logging/logging.mjs';
 import { promisesHandler } from 'util/promises.mjs';
 import { spotlightEndpoint, confidenceValues } from 'conf/config.mjs';
 
@@ -257,6 +257,14 @@ export const annotateText = async (
 	};
 };
 
+export const annotateArray = async (texts, endpoint) => {
+	const body = JSON.stringify({ texts });
+	const headers = { "Content-Type": "application/json" };
+	const result = await fetch(endpoint, { body, headers, method: 'POST' });
+	const annotations = await result.json();
+	return annotations;
+};
+
 /**
  * Results for the higher level process of annotating an ElasticSearch document.
  * @typedef documentAnnotationResult
@@ -316,11 +324,8 @@ const annotateBatch = async (
 	includeMetaData
 ) => {
 
-	const annotateDocument_ = doc => annotateDocument(
-		doc, fieldName, { endpoint, includeMetaData }
-	);
 	const toBulkFormat = doc => ({
-		"_id": doc.id,
+		"_id": doc._id,
 		data: {
 			[newFieldName]: doc.annotations,
 			...doc.metadata && { [`${newFieldName}_metadata`]: doc.metadata }
@@ -329,13 +334,24 @@ const annotateBatch = async (
 
 	// filter out docs with empty text
 	const nonEmptyDocs = docs.filter(doc => doc._source[fieldName]);
-	const promises = _.map(nonEmptyDocs, annotateDocument_);
-	const annotations = await promisesHandler(promises);
-	const nonEmptyAnnotations = _.filter(
-		annotations,
+	const texts = _.map(nonEmptyDocs, _.getPath(`_source.${fieldName}`));
+	const results = await annotateArray(texts, endpoint);
+	const inputs = _.map(
+		_.zip(docs, results),
+		([doc, data]) => ({ ...doc, ...data })
+	);
+	const [annotations, empties] = _.partition(
+		inputs,
 		doc => doc.annotations.length !== 0
 	);
-	const bulkFormat = _.map(nonEmptyAnnotations, toBulkFormat);
+
+	if (empties.length) {
+		_.forEach(
+			empties,
+			doc => logger.warn(`Empty doc: ${JSON.stringify(doc)}`)
+		);
+	}
+	const bulkFormat = _.map(annotations, toBulkFormat);
 	return bulkFormat;
 };
 
@@ -367,11 +383,12 @@ export const annotateIndex = async (
 	endpoint,
 	field,
 	{
-		newField='dbpedia_entities',
+		batchSize=50,
+		groupSize=4,
 		includeMetaData=true,
-		batchSize=10,
+		newField='dbpedia_entities',
 		pages='all',
-		pageSize=1000,
+		pageSize=10000,
 		progress=null,
 	}={}
 ) => {
@@ -387,16 +404,25 @@ export const annotateIndex = async (
 	let page;
 	for await (page of scroller) {
 		const batches = batch(page.hits.hits, batchSize);
+		const groups = batch(batches, groupSize);
 		const updates = [];
-		for await (const docs of batches) {
-			const annotatedBatch = await annotateBatch(
-				docs, field, newField, endpoint, includeMetaData
+		for await (const group of groups) {
+			// eslint-disable-next-line no-await-in-loop
+			const promises = _.map(group, docs =>
+				annotateBatch(docs, field, newField, endpoint, includeMetaData)
 			);
-			updates.push(annotatedBatch);
-			bar.increment(docs.length);
+			const resolvedPromises = await promisesHandler(promises);
+			const annotations = _.flatten(resolvedPromises);
+			updates.push(annotations);
+			bar.increment(_.flatten(group).length);
 		};
 		const flattenedUpdates = _.flatten(updates);
-		await bulkRequest(domain, index, flattenedUpdates, 'update', { error: false });
+
+		// this is likely to be too big, so separate by default size
+		const batchedUpdates = batch(flattenedUpdates, 500);
+		for await (const update_ of batchedUpdates) {
+			await bulkRequest(domain, index, update_, 'update', { error: false });
+		}
 	}
 
 	bar.stop();

--- a/src/node_modules/es/index.mjs
+++ b/src/node_modules/es/index.mjs
@@ -49,7 +49,7 @@ export const createIndex = async (
 	index,
 	{ payload = {} } = {}
 ) => {
-	const path = name;
+	const path = index;
 	const parsedPayload = typeof payload !== 'string' ? JSON.stringify(payload) : payload;
 	const request = buildRequest(domain, path, 'PUT', { payload: parsedPayload });
 	const { body: response, code } = await makeRequest(request);

--- a/src/node_modules/terraform/configuration.mjs
+++ b/src/node_modules/terraform/configuration.mjs
@@ -1,12 +1,10 @@
-import * as fs from 'fs';
-
 import * as _ from 'lamb';
 
+import { createPathAndWriteObject } from 'util/path.mjs';
 import { ami, scaffold, spotlightInstanceType } from 'conf/infrastructure.mjs';
-import { stringify } from '@svizzle/utils';
 
 
-export const generateConfiguration = (workers, path=null) => {
+export const generateConfiguration = async(workers, path=null) => {
 	const identifiers = [...Array(workers).keys()];
 	const resource = _.map(identifiers, id => (
 		{
@@ -43,7 +41,7 @@ export const generateConfiguration = (workers, path=null) => {
 	};
 
 	if (path) {
-		fs.writeFileSync(path, stringify(configuration));
+		await createPathAndWriteObject(path, configuration);
 	}
 	return configuration;
 };

--- a/src/node_modules/util/path.mjs
+++ b/src/node_modules/util/path.mjs
@@ -1,0 +1,10 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+import { stringify } from '@svizzle/utils';
+
+export const createPathAndWriteObject = async (path_, data) => {
+	const directory = path.dirname(path_);
+	await fs.mkdir(directory, { recursive: true });
+	await fs.writeFile(path_, stringify(data));
+};

--- a/src/services/annotation/config.mjs
+++ b/src/services/annotation/config.mjs
@@ -1,7 +1,7 @@
 export const PORT = 4000;
 
-export const spotlightEndpoint = "http://api.dap-tools.uk/spotlight";
-export const annotationEndpoint = new URL('annotate', spotlightEndpoint);
+export const spotlightEndpoint = "https://api.dap-tools.uk/spotlight";
+export const annotationEndpoint = `${spotlightEndpoint}/annotate`;
 export const authenticationEndpoint = 'https://api.dap-tools.uk/auth/authenticate';
 export const notificationEmail = 'annotations@dap-tools.uk';
 export const MAX_WORKERS=4;

--- a/src/services/annotation/service/checks.mjs
+++ b/src/services/annotation/service/checks.mjs
@@ -40,6 +40,7 @@ const objectAccessible = async (bucket, key) => {
 	}
 };
 
+
 const bucketWritable = async (bucket, key) => {
 	const uri = buildS3Uri(bucket, key);
 	const data = { "test": "data" };
@@ -62,9 +63,10 @@ const bucketWritable = async (bucket, key) => {
 	}
 };
 
-const outputBucketAlreadyExists = async (bucket, key) => {
+const objectExists = async (bucket, key) => {
 	const uri = buildS3Uri(bucket, key);
-	if (await objectAccessible(bucket, key)) {
+	const { error } = await objectAccessible(bucket, key);
+	if (!error) {
 		return {
 			error: `Object already exists at ${uri}. Please ensure that you're not overwriting an existing S3 object.`,
 			code: codes.S3_OBJECT_EXISTS
@@ -78,7 +80,7 @@ export const checkS3 = async (inBucket, inKey, outBucket, outKey) => {
 	if (readCheck.error) {
 		return readCheck;
 	}
-	const overwriteCheck = await outputBucketAlreadyExists(outBucket, outKey);
+	const overwriteCheck = await objectExists(outBucket, outKey);
 	if (overwriteCheck.error) {
 		return overwriteCheck;
 	}

--- a/src/services/annotation/service/terraform.mjs
+++ b/src/services/annotation/service/terraform.mjs
@@ -16,7 +16,7 @@ const parseResponse = response => {
 	return response;
 };
 const request = async path => {
-	const endpoint = new URL(path, spotlightEndpoint);
+	const endpoint = `${spotlightEndpoint}/${path}`;
 	const response = await fetch(endpoint);
 	return parseResponse(response);
 };
@@ -27,11 +27,10 @@ export const state = () => request('state');
 
 export const provision = async workers => {
 
-	const endpoint = new URL('provision', spotlightEndpoint);
+	const endpoint = `${spotlightEndpoint}/provision`;
 	const headers = { 'Content-Type': 'application/json' };
 	const body = stringify({ workers });
 	const response = await fetch(endpoint, { method: 'POST', headers, body });
-
 	return new Promise(async (resolve, reject) => {
 		const {status: code} = parseResponse(response);
 		if (code !== 200) {

--- a/src/services/annotationMapper/Dockerfile
+++ b/src/services/annotationMapper/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+# Build from the root directory of the repository:
+# docker build -t ghcr.io/nestauk/annotation-mapper -f src/services/annotationMapper/Dockerfile .
+FROM node
+WORKDIR /dap_dv_backends
+COPY . . 
+RUN npm install
+CMD ["node", "src/services/annotator/service/app.mjs"]
+EXPOSE 4000

--- a/src/services/annotationMapper/config.mjs
+++ b/src/services/annotationMapper/config.mjs
@@ -1,0 +1,5 @@
+export const PORT = 4000;
+
+// the odd looking domain 'worker' is created when launching docker containers.
+// see /src/services/spotlight/spotlightDockerCommand.sh
+export const DOCKER_SPOTLIGHT_ENDPOINT = 'http://worker:2222/rest/annotate';

--- a/src/services/annotationMapper/service/app.mjs
+++ b/src/services/annotationMapper/service/app.mjs
@@ -1,0 +1,22 @@
+import Fastify from 'fastify';
+
+import { PORT } from '../config.mjs';
+import { routes } from './routes.mjs';
+
+const fastify = Fastify({
+	logger: true
+});
+
+fastify.register(routes);
+
+const start = async () => {
+	try {
+		await fastify.listen({ host: '0.0.0.0', port: PORT });
+		console.log(`Listening at http://localhost:${PORT}`);
+	} catch (err) {
+		fastify.log.error(err);
+		throw new Error(err);
+	}
+};
+
+start();

--- a/src/services/annotationMapper/service/routes.mjs
+++ b/src/services/annotationMapper/service/routes.mjs
@@ -1,0 +1,28 @@
+import * as _ from 'lamb';
+
+import { annotateText } from 'dbpedia/spotlight.mjs';
+
+import { DOCKER_SPOTLIGHT_ENDPOINT } from '../config.mjs';
+
+
+export const routes = (fastify, options, done) => {
+
+	fastify.post('/annotate', async (request, reply) => {
+		const { texts, includeMetaData=true } = request.body;
+		const promises = _.map(
+			texts,
+			t => annotateText(t, {
+				includeMetaData,
+				endpoint: DOCKER_SPOTLIGHT_ENDPOINT
+			}));
+
+		const results = await Promise.allSettled(promises);
+		const annotations = _.map(
+			results,
+			r => r.status === 'fulfilled' ? r.value : { annotations: [] }
+		);
+		reply.send(annotations);
+	});
+
+	done();
+};

--- a/src/services/spotlight/config.mjs
+++ b/src/services/spotlight/config.mjs
@@ -2,6 +2,9 @@ import * as path from 'path';
 
 import { __dirname } from './service/util.mjs';
 
+export const spotlightEndpoint = "https://api.dap-tools.uk/spotlight";
 
+export const PORT = 3000;
+export const WORKER_PORT = 4000;
 export const SERVER_DIRECTORY = path.join(__dirname, '..');
 export const TERRAFORM_DIRECTORY = path.join(SERVER_DIRECTORY, 'terraform');

--- a/src/services/spotlight/nginx.conf
+++ b/src/services/spotlight/nginx.conf
@@ -1,20 +1,7 @@
 events {}
 http {
-	upstream spotlight {
-		
-	}
-
-	server {
-		listen 2222;
-		location / {
-			proxy_pass http://spotlight;
-		}
-	}
 	server {
 		listen 80;
-		location /annotate {
-			proxy_pass http://spotlight/rest/annotate;
-		}
 		location / {
 			proxy_pass http://localhost:3000;
 		}

--- a/src/services/spotlight/service/app.mjs
+++ b/src/services/spotlight/service/app.mjs
@@ -3,13 +3,12 @@ import express from 'express';
 import { destroy } from 'terraform/commands.mjs';
 import { getCurrentState } from 'terraform/state.mjs';
 
-import { TERRAFORM_DIRECTORY } from '../config.mjs';
+import { PORT, spotlightEndpoint, TERRAFORM_DIRECTORY } from '../config.mjs';
 import { bootstrap, configureLoadBalancer, setup } from './infrastructure.mjs';
-import { state } from '../state.mjs';
+import { state } from './state.mjs';
 
 
 const app = express();
-const port = 3000;
 
 await bootstrap();
 
@@ -19,7 +18,7 @@ app.use(express.json()); // for parsing application/json
 app.post('/provision', (req, res) => {
 	const { workers=4 } = req.body;
 	if (workers === 0) {
-		return res.redirect('/teardown');
+		return res.redirect(`${spotlightEndpoint}/teardown`);
 	}
 	state.status = 'scheduling';
 	setup(workers).then(({ status, workers: workers_, endpoints }) => {
@@ -52,8 +51,8 @@ app.get('/status', (_, res) => {
 	res.send(state);
 });
 
-app.listen(port, () => {
-	console.log(`Listening on port ${port}`);
+app.listen(PORT, () => {
+	console.log(`Listening on port ${PORT}`);
 });
 
 

--- a/src/services/spotlight/spotlightDockerCommand.sh
+++ b/src/services/spotlight/spotlightDockerCommand.sh
@@ -1,5 +1,10 @@
+docker network create annotator-network
+
 docker run -dp 2222:2222 \
+     --network annotator-network --network-alias worker \
      -w /app -v '/home/ubuntu:/app' \
      --memory=10g \
      openjdk:8-jre-alpine \
      sh -c 'java -Dfile.encoding=UTF-8 -Xmx10G -jar dbpedia-spotlight-1.1.jar en http://0.0.0.0:2222/rest'
+
+docker run -dp 4000:4000 --network annotator-network ghcr.io/nestauk/annotation-mapper:latest


### PR DESCRIPTION
This PR changes the type of annotation request a spotlight worker node recieves. Instead, the worker will recieve an array of text, which means that the node itself will need to host not only a spotlight container, but also a small server capable of handling the logic needed for these requests. As a result, the worker nodes have much less network overhead, and they're processing much larger chunks of data.

closes #189