### PR TITLE
Get count of docs from #indexToBucket

### DIFF
--- a/src/node_modules/aws/s3.mjs
+++ b/src/node_modules/aws/s3.mjs
@@ -187,6 +187,7 @@ export const bucketToIndex = async (
 	chunkSize=256_000,
 ) => {
 
+	let count = 0;
 	const method = idField ? 'create' : 'index';
 	const formatObject = _.pipe([
 		_.pairs,
@@ -219,7 +220,9 @@ export const bucketToIndex = async (
 			bulkFormat,
 			method
 		);
+		count += docs.length;
 	}
+	return count;
 };
 
 /* Index to Bucket Specific Functions */

--- a/src/services/annotation/service/routes.mjs
+++ b/src/services/annotation/service/routes.mjs
@@ -62,7 +62,7 @@ export const routes = (fastify, options, done) => {
 		const { email } = parseBasicAuth(request.headers.authorization);
 
 		const index = id;
-		await bucketToIndex(
+		const total = await bucketToIndex(
 			index,
 			domain,
 			inBucket,
@@ -70,8 +70,6 @@ export const routes = (fastify, options, done) => {
 			idField
 		);
 
-		// should there be a delay between above?
-		const total = await count(domain, index);
 		const callback = () => {
 			sendEmail(
 				email,


### PR DESCRIPTION
Get's the total number of documents that have been transferred to an
ES index from an S3 bucket by counting the docs used from the stream
iterator. Will give an exact count, as opposed to using the count API
from ElasticSearch, as this wasn't guaranteed to return the correct
result.

fixes #193