### PR TITLE
Add Logstash ingestion Pipeline for MYSQL -> ES

### DIFF
--- a/data/hpmt/README.md
+++ b/data/hpmt/README.md
@@ -1,0 +1,72 @@
+# Logstash Ingestion Pipeline
+
+## How to run
+
+**N.B:** the following assumes you are running the ingestion on Ubuntu 22.04. If
+this is not the case, please install the relevant OpenSearch Logstash 
+version for your system.
+
+Download the JDBC driver
+
+`wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-8.0.31.tar.gz`
+
+Untar
+
+`tar -xvf /<path_to_jdbc_tarball>`
+
+Install the `OpenSearch` version of `Logstash` (needed for AWS managed ES domains)
+
+(Check before that the link below is the latest version [here](https://opensearch.org/downloads.html))
+
+`wget https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-8.4.0-linux-x64.tar.gz`
+
+Untar
+
+`tar -xvf <path_to_logstash_tarball> -C <directory>`
+
+Set environment variables
+
+```sh
+# mysql connector, tested and working with mysql-connector-j-8.0.31.jar
+export JDBC_DRIVER_PATH=<path_to_driver_directory>/mysql-connector-<version>.jar
+# username and password for mysql db connection
+export JDBC_USER=<mysql_username>
+export JDBC_PASSWORD=<mysql_db_password>
+# aws access, for access to the hosted ElasticSearch index/domain
+export AWS_ACCESS_ID=<aws_access_key_id>
+export AWS_ACCESS_KEY=<aws_secret_access_key>
+# name of connection string to the hosted db
+# this must contain the path to the db itself
+export JDBC_CONNECTION_STRING=jdbc:<connection_string>:<port>/<database>
+# name of table to ingest
+export LOGSTASH_INPUT_TABLE=<your_table_name>
+# name of ElasticSearch domain and index to write data to
+export LOGSTASH_OUTPUT_DOMAIN=<domain> 
+export LOGSTASH_OUTPUT_INDEX=<index>
+```
+
+It's usually easier to copy these commands to a configuration file, set the
+appropriate values, then `source pipeline.rc` or equivalent to quickly load in the
+environment variables.
+
+Change to `Logstash` directory
+
+`cd /<path>/logstash-<version>`
+
+**N.B**: The pipeline expects an auto-increment column named `id` in order to be
+able to run, please ensure this exists on the input MySQL table before running
+the pipeline.
+
+Run executable pointing to the pipeline config in this directory
+
+`bin/logstash -f /<path_to_repo>/data/hpmt/pipeline.conf`
+
+### Troubleshooting
+
+If the pipeline runs OK but you get a message like
+
+`The driver has not received any packets from the server.`
+
+Make sure the instance you're running this pipeline from has permissions to
+access the DB, e.g. that the IP is listed in the allowed incoming requests in
+the EC2/RDS security configuration.

--- a/data/hpmt/pipeline_v0.conf
+++ b/data/hpmt/pipeline_v0.conf
@@ -1,0 +1,112 @@
+input {
+	jdbc {
+		clean_run => true
+		jdbc_driver_library => "${JDBC_DRIVER_PATH}"
+		jdbc_driver_class => "com.mysql.cj.jdbc.Driver"
+		jdbc_connection_string => "${JDBC_CONNECTION_STRING}" 
+		jdbc_user => "${JDBC_USER}"
+		jdbc_password => "${JDBC_PASSWORD}" 
+		use_column_value => true
+		tracking_column => "id"
+		schedule => "*/5 * * * * *"
+		# unnamed: 0 is due to pandas indexing error (I think), but we need an index
+		# of some description to ensure data is not duplicated during SQL query
+		statement => "SELECT * FROM ${LOGSTASH_INPUT_TABLE} WHERE id >= :sql_last_value ORDER BY id LIMIT 100000"
+	}
+}
+filter {
+	mutate {
+		copy => { "id" => "[@metadata][_id]" }
+		remove_field => ["id", "@version", "@timestamp", "local_authority_label", "pcds", "pcds_installer"]
+		rename => {
+			"design" => "hp_feature_design"
+			"flow_temp" => "hp_feature_flow_temperature"
+			"tech_type" => "hp_feature_heat_source"
+			"hp_type" => "hp_feature_heat_system"
+			"capacity" => "hp_feature_power_capacity"
+			"estimated_annual_generation" => "hp_feature_power_generation"
+			"scop" => "hp_feature_scop"
+			"manufacturer" => "hp_id_brand"
+			"product_name" => "hp_id_model"
+			"hp_installed" => "hp_installed_flag"
+			"cost" => "installation_cost"
+			"hp_install_date" => "installation_date"
+			"hp_install_year" => "installation_date_year"
+			"lat_installer" => "installer_geo_coord_lat"
+			"long_installer" => "installer_geo_coord_lon"
+			"itl121cd_installer" => "installer_geo_region_itl21_1_id"
+			"itl121nm_installer" => "installer_geo_region_itl21_1_name"
+			"itl221cd_installer" => "installer_geo_region_itl21_2_id"
+			"itl221nm_installer" => "installer_geo_region_itl21_2_name"
+			"itl321cd_installer" => "installer_geo_region_itl21_3_id"
+			"itl321nm_installer" => "installer_geo_region_itl21_3_name"
+			"lau121cd_installer" => "installer_geo_region_lau21_1_id"
+			"lau121nm_installer" => "installer_geo_region_lau21_1_name"
+			"lsoa11cd_installer" => "installer_geo_region_lsoa11_id"
+			"lsoa11nm_installer" => "installer_geo_region_lsoa11_name"
+			"msoa11cd_installer" => "installer_geo_region_msoa11_id"
+			"msoa11nm_installer" => "installer_geo_region_msoa11_name"
+			"installer_id" => "installer_id"
+			"installer_name" => "installer_name"
+			"floor_energy_eff" => "property_energy_efficiency_floor"
+			"hot_water_energy_eff" => "property_energy_efficiency_hot_water"
+			"lighting_energy_eff" => "property_energy_efficiency_lighting"
+			"mainheat_energy_eff" => "property_energy_efficiency_main_heat"
+			"roof_energy_eff" => "property_energy_efficiency_roof"
+			"walls_energy_eff" => "property_energy_efficiency_walls"
+			"windows_energy_eff" => "property_energy_efficiency_windows"
+			"current_energy_rating" => "property_energy_rating_current"
+			"potential_energy_rating" => "property_energy_rating_potential"
+			"built_form" => "property_feature_built_form"
+			"construction_age_band" => "property_feature_construction_age_band"
+			"glazed_area" => "property_feature_glazed_area"
+			"glazed_type" => "property_feature_glazed_type"
+			"number_habitable_rooms" => "property_feature_number_habitable_rooms"
+			"total_floor_area" => "property_feature_total_floor_area"
+			"property_type" => "property_feature_type"
+			"lat" => "property_geo_coord_lat"
+			"long" => "property_geo_coord_lon"
+			"country" => "property_geo_region_country"
+			"itl121cd_installation" => "property_geo_region_itl21_1_id"
+			"itl121nm_installation" => "property_geo_region_itl21_1_name"
+			"itl221cd_installation" => "property_geo_region_itl21_2_id"
+			"itl221nm_installation" => "property_geo_region_itl21_2_name"
+			"itl321cd_installation" => "property_geo_region_itl21_3_id"
+			"itl321nm_installation" => "property_geo_region_itl21_3_name"
+			"lau121cd_installation" => "property_geo_region_lau21_1_id"
+			"lau121nm_installation" => "property_geo_region_lau21_1_name"
+			"lsoa11cd_installation" => "property_geo_region_lsoa11_id"
+			"lsoa11nm_installation" => "property_geo_region_lsoa11_name"
+			"msoa11cd_installation" => "property_geo_region_msoa11_id"
+			"msoa11nm_installation" => "property_geo_region_msoa11_name"
+			"postcode" => "property_geo_region_postcode"
+			"uprn" => "property_id_uprn"
+			"inspection_date" => "property_meta_epc_inspection_date"
+			"transaction_type" => "property_meta_epc_transaction_type"
+			"mcs_available" => "property_meta_mcs_available"
+			"heating_fuel" => "property_supply_heating_fuel_type"
+			"heating_system" => "property_supply_heating_system"
+			"mainheat_description" => "property_supply_main_heat_description"
+			"mains_gas_flag" => "property_supply_mains_gas_flag"
+			"photo_supply" => "property_supply_photovoltaic"
+			"solar_water_heating_flag" => "property_supply_solar_water_heating_flag"
+			"tenure" => "property_tenure" 
+		}
+	}
+}
+
+output {
+	opensearch {
+		hosts => ["${LOGSTASH_OUTPUT_DOMAIN}:443"]
+		auth_type => {
+			type => 'aws_iam'
+			aws_access_key_id => "${AWS_ACCESS_ID}"
+			aws_secret_access_key => "${AWS_ACCESS_KEY}"
+			region => 'eu-west-2'
+		}
+		index=> "${LOGSTASH_OUTPUT_INDEX}"
+		ecs_compatibility => disabled
+		document_id => "%{[@metadata][_id]}"
+	}
+}
+


### PR DESCRIPTION
Adds a configuration file to use logstash for ingesting data from a MySQL input and outputting to an ElasticSearch index. Also adds a README to explain how to configure and run the process.

closes #204