### PR TITLE
Fix bug where docs weren't annotating

### DIFF
--- a/src/bin/s3/bucketToIndex.mjs
+++ b/src/bin/s3/bucketToIndex.mjs
@@ -40,9 +40,7 @@ const main = async () => {
 		options.domain,
 		options.bucket,
 		options.key,
-		options.idField,
-		options.format,
-		options.chunkSize
+		...options
 	);
 };
 

--- a/src/node_modules/aws/s3.mjs
+++ b/src/node_modules/aws/s3.mjs
@@ -182,12 +182,15 @@ export const bucketToIndex = async (
 	domain,
 	bucket,
 	key,
-	idField=null,
-	format='array',
-	chunkSize=256_000,
+	{
+		idField=null,
+		format='array',
+		chunkSize=8_388_608, // 8MB,
+		refresh=false
+	}={}
 ) => {
 
-	let count = 0;
+	let count_ = 0;
 	const method = idField ? 'create' : 'index';
 	const formatObject = _.pipe([
 		_.pairs,
@@ -218,11 +221,12 @@ export const bucketToIndex = async (
 			domain,
 			index,
 			bulkFormat,
-			method
+			method,
+			{ refresh }
 		);
-		count += docs.length;
+		count_ += docs.length;
 	}
-	return count;
+	return count_;
 };
 
 /* Index to Bucket Specific Functions */

--- a/src/node_modules/dbpedia/spotlight.mjs
+++ b/src/node_modules/dbpedia/spotlight.mjs
@@ -259,7 +259,7 @@ export const annotateText = async (
 
 export const annotateArray = async (texts, endpoint) => {
 	const body = JSON.stringify({ texts });
-	const headers = { "Content-Type": "application/json" };
+	const headers = { 'Content-Type': 'application/json' };
 	const result = await fetch(endpoint, { body, headers, method: 'POST' });
 	const annotations = await result.json();
 	return annotations;
@@ -325,7 +325,7 @@ const annotateBatch = async (
 ) => {
 
 	const toBulkFormat = doc => ({
-		"_id": doc._id,
+		'_id': doc._id,
 		data: {
 			[newFieldName]: doc.annotations,
 			...doc.metadata && { [`${newFieldName}_metadata`]: doc.metadata }
@@ -334,10 +334,15 @@ const annotateBatch = async (
 
 	// filter out docs with empty text
 	const nonEmptyDocs = docs.filter(doc => doc._source[fieldName]);
+	const emptyDocs = docs.filter(doc => !doc._source[fieldName]);
+	_.forEach(
+		emptyDocs,
+		doc => logger.warn(`Empty field: ${JSON.stringify(doc)}`)
+	);
 	const texts = _.map(nonEmptyDocs, _.getPath(`_source.${fieldName}`));
 	const results = await annotateArray(texts, endpoint);
 	const inputs = _.map(
-		_.zip(docs, results),
+		_.zip(nonEmptyDocs, results),
 		([doc, data]) => ({ ...doc, ...data })
 	);
 	const [annotations, empties] = _.partition(
@@ -421,7 +426,13 @@ export const annotateIndex = async (
 		// this is likely to be too big, so separate by default size
 		const batchedUpdates = batch(flattenedUpdates, 500);
 		for await (const update_ of batchedUpdates) {
-			await bulkRequest(domain, index, update_, 'update', { error: false });
+			await bulkRequest(
+				domain,
+				index,
+				update_,
+				'update',
+				{ error: false, refresh: 'wait_for' }
+			);
 		}
 	}
 

--- a/src/node_modules/es/bulk.mjs
+++ b/src/node_modules/es/bulk.mjs
@@ -2,6 +2,7 @@ import { stringify } from '@svizzle/utils';
 import * as _ from 'lamb';
 
 import { buildRequest, makeRequest } from 'es/requests.mjs';
+import { logger } from 'logging/logging.mjs';
 
 const generateBulkPayload = (method, index) => _.pipe([
 	_.flatMapWith(doc =>
@@ -32,7 +33,7 @@ export const bulkRequest = async (
 	index,
 	documents,
 	method,
-	{ error=true }={}
+	{ error=true, refresh=false }={}
 ) => {
 	const path = `${index}/_bulk`;
 	const generate = generateBulkPayload(method, index);
@@ -45,14 +46,14 @@ export const bulkRequest = async (
 	}
 	const request = buildRequest(
 		domain, path, 'POST',
-		{ payload, contentType: 'application/x-ndjson' }
+		{ payload, contentType: 'application/x-ndjson', query: { refresh } }
 	);
 	const { body: response, code } = await makeRequest(request);
 	if (response.error) {
 		if (error) {
 			throw new Error(stringify(response));
 		} else {
-			console.error(stringify(response));
+			logger.error(stringify(response));
 		}
 	}
 	return { response, code };

--- a/src/services/annotation/service/progress.mjs
+++ b/src/services/annotation/service/progress.mjs
@@ -1,7 +1,5 @@
 import { performance } from 'perf_hooks';
 
-import { sendEmail } from 'aws/email.mjs';
-
 
 export const Progress = class {
 	constructor(total, callback) {
@@ -15,6 +13,10 @@ export const Progress = class {
 	increment(amount) {
 		this.current += amount;
 	};
+
+	setTotal(total) {
+		this.total = total;
+	}
 
 	status() {
 		if (this.current === 0) {


### PR DESCRIPTION
The bulk API for ElasticSearch wasn't waiting for the shards to refresh, resulting in a significant portion of documents not being annotated at all. By using the refresh=wait_for query paramater, we ensure that the docs are both uploaded and ready to be annoated before launching the service.

Also:
- make the "simple" S3 output format the default.

fixes #206