### PR TITLE
Surround the makeRequest function with retry logic

### DIFF
--- a/src/node_modules/es/requests.mjs
+++ b/src/node_modules/es/requests.mjs
@@ -4,6 +4,8 @@ import { NodeHttpHandler } from '@aws-sdk/node-http-handler';
 import { HttpRequest } from '@aws-sdk/protocol-http';
 import { SignatureV4 } from '@aws-sdk/signature-v4';
 
+import { sleep } from 'util/time.mjs';
+
 const { Sha256 } = sha256;
 
 const signer = new SignatureV4({
@@ -15,7 +17,7 @@ const signer = new SignatureV4({
 
 /**
  * @function buildRequest
- * @description builds a HttpRequest object using the AWS sdk. Needed for siginin the request using Environment variables.
+ * @description builds a HttpRequest object using the AWS sdk. Needed for signing the request using Environment variables.
  * @param {string} domain ElasticSearch domain on which to make request.
  * @param {string} path - additional path, appended after the domain in the request URL.
  * @param {string} method - HTTP request method (GET, POST, etc.).
@@ -55,25 +57,29 @@ export const buildRequest = (
  */
 const parseResponseBody = response => {
 	let responseBody = '';
-	return new Promise((resolve, _) => {
+	return new Promise((resolve, reject) => {
 		response.body.on('data', chunk => {
 			responseBody += chunk;
 		});
 		response.body.on('end', () => {
-			resolve(JSON.parse(responseBody));
+			try {
+				resolve(JSON.parse(responseBody));
+			} catch (e) {
+				reject(e);
+			}
 		});
 	});
 };
 
 /**
- * @function makeRequest
+ * @function _makeRequest
  * @description makes a request using a HttpRequest object.
  * @param {HttpRequest} request - the HttpRequest object built using {@link buildRequest}
  * @param {Object} [options={}]
  * @param {boolean} [options.verbose] - whether to log the output of the request and response.
  * @returns {Object} the HttpResponse object
  */
-export const makeRequest = async (request, { verbose = false } = {}) => {
+const _makeRequest = async request => {
 
 	// Sign the request
 	const signedRequest = await signer.sign(request);
@@ -82,9 +88,34 @@ export const makeRequest = async (request, { verbose = false } = {}) => {
 	const client = new NodeHttpHandler();
 	const { response } = await client.handle(signedRequest);
 	const responseBody = await parseResponseBody(response);
+
 	return {
 		code: response.statusCode,
 		message: response.body.statusMessage,
 		body: responseBody,
 	};
+};
+
+/**
+ * @function makeRequest
+ * @description wraps the makeRequest function with try/catch and retry logic.
+ * @param {HttpRequest} request - the HttpRequest object built using {@link buildRequest}
+ * @param {Object} [options={}]
+ * @param {boolean} [options.retry] - how long to wait between trys.
+ * @param {boolean} [options.limit] - how many times to retry.
+ * @returns {Object} the HttpResponse object
+ */
+export const makeRequest = async (request, { retry=null, limit=10 }={}) => {
+	const promise = _makeRequest(request);
+	const result = promise
+	.then(value => value)
+	.catch(async err => {
+		if (retry && limit !== 0) {
+			await sleep(retry);
+			return makeRequest(request, { retry, limit: limit-1 });
+		}
+		throw err;
+
+	});
+	return result;
 };

--- a/src/node_modules/es/search.mjs
+++ b/src/node_modules/es/search.mjs
@@ -31,7 +31,7 @@ const first = async (domain, index, size) => {
 		payload,
 		query,
 	});
-	const { body: result } = await makeRequest(firstRequest);
+	const { body: result } = await makeRequest(firstRequest, { retry: 5000 });
 	return result;
 };
 
@@ -48,7 +48,7 @@ const subsequent = async (domain, id) => {
 	const subsequentRequest = buildRequest(domain, path, 'POST', {
 		payload,
 	});
-	const { body: result } = await makeRequest(subsequentRequest);
+	const { body: result } = await makeRequest(subsequentRequest, { retry: 5000 });
 	return result;
 };
 


### PR DESCRIPTION
This allows all requests made to the ElasticSearch API to be "retried", if the paramaters are supplied. i.e. you can supply a retry time and retry limit to the function, so that it will wait/pause between executions. This is to fix the ES scroll bug, where the bulk request queues were being overloaded when copying an index to an s3 bucket.

fixes #208