### PR TITLE
Port Terraform configuration to service

### DIFF
--- a/src/services/spotlight/config.mjs
+++ b/src/services/spotlight/config.mjs
@@ -8,3 +8,29 @@ export const PORT = 3000;
 export const WORKER_PORT = 4000;
 export const SERVER_DIRECTORY = path.join(__dirname, '..');
 export const TERRAFORM_DIRECTORY = path.join(SERVER_DIRECTORY, 'terraform');
+
+export const ami = 'ami-06cb614d0f047d106';
+export const spotlightInstanceType = 't2.xlarge';
+
+export const scaffold = {
+	provider: [
+		{
+			aws: {
+				region: 'eu-west-2',
+			},
+		},
+	],
+	terraform: [
+		{
+			required_providers: [
+				{
+					aws: {
+						source: 'hashicorp/aws',
+						version: '~\u003e 4.16',
+					},
+				},
+			],
+			required_version: '\u003e= 1.2.0',
+		},
+	],
+};

--- a/src/services/spotlight/service/configuration.mjs
+++ b/src/services/spotlight/service/configuration.mjs
@@ -1,0 +1,48 @@
+import * as _ from 'lamb';
+
+import { createPathAndWriteObject } from 'dap_dv_backends_utils/util/path.mjs';
+import { ami, scaffold, spotlightInstanceType } from '../config.mjs';
+
+
+export const generateConfiguration = async(workers, path=null) => {
+	const identifiers = [...Array(workers).keys()];
+	const resource = _.map(identifiers, id => (
+		{
+			aws_instance: [
+				{
+					[`spotlight-node-${id}`]: [
+						{
+							ami,
+							instance_type: spotlightInstanceType,
+							key_name: 'spotlight',
+							vpc_security_group_ids: ['sg-026313a646e2d8470'],
+							tags: {
+								Name: `spotlight-node-${id}`,
+							},
+						},
+					],
+				},
+			],
+		}
+	));
+	const output = _.map(identifiers, id => (
+		{
+			[`spotlight-node-${id}-public_ip`]: [
+				{
+					"value": `\${aws_instance.spotlight-node-${id}.public_ip}`
+				}
+			]
+		}
+	));
+	const configuration = {
+		...scaffold,
+		output,
+		resource
+	};
+
+	if (path) {
+		await createPathAndWriteObject(path, configuration);
+	}
+	return configuration;
+};
+

--- a/src/services/spotlight/service/infrastructure.mjs
+++ b/src/services/spotlight/service/infrastructure.mjs
@@ -5,12 +5,12 @@ import * as _ from 'lamb';
 import * as path from 'path';
 
 import { init, apply } from 'dap_dv_backends_utils/terraform/commands.mjs';
-import { generateConfiguration } from 'dap_dv_backends_utils/terraform/configuration.mjs';
 import { getCurrentState } from 'dap_dv_backends_utils/terraform/state.mjs';
 import { displayCommandOutput } from 'dap_dv_backends_utils/util/shell.mjs';
 import { sleep } from 'dap_dv_backends_utils/util/time.mjs';
 
 import { WORKER_PORT, SERVER_DIRECTORY, TERRAFORM_DIRECTORY } from '../config.mjs';
+import { generateConfiguration } from './configuration.mjs';
 import { getIps, endpointToIp, getEndpoints, getNewEndpoints, spotlightEndpointPromise } from './util.mjs';
 import { state } from './state.mjs';
 


### PR DESCRIPTION
Ports the configuration for setting up nodes on AWS to the service, instead of keeping this information in the utils package, which is intended to be more generic and serve only utilities.

closes #219